### PR TITLE
Refactor: Minimize README and consolidate template documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+Thank you for your interest in contributing! This document provides guidelines for contributing to this project.
+
+## How to Contribute
+
+### 1. Fork and Clone
+
+```bash
+# Fork the repository on GitHub, then clone your fork
+git clone git@github.com:YOUR_USERNAME/YOUR_REPO_NAME.git
+cd YOUR_REPO_NAME
+```
+
+### 2. Create a Feature Branch
+
+```bash
+# Create a branch for your changes
+git checkout -b feature/your-feature-name
+```
+
+### 3. Make Your Changes
+
+- Follow existing code style and conventions
+- Add tests for new functionality
+- Update documentation as needed
+- Ensure all tests pass
+
+### 4. Commit Your Changes
+
+```bash
+# Stage your changes
+git add .
+
+# Create a descriptive commit message
+git commit -m "Add feature: brief description of changes"
+```
+
+### 5. Push and Create a Pull Request
+
+```bash
+# Push your branch to your fork
+git push -u origin feature/your-feature-name
+
+# Create a pull request on GitHub
+gh pr create --base main --title "Your PR title" --body "Description of changes"
+```
+
+## Pull Request Guidelines
+
+- **Title**: Use a clear, descriptive title
+- **Description**: Explain what changes you made and why
+- **Scope**: Keep PRs focused on a single feature or fix
+- **Tests**: Include tests for new functionality
+- **Documentation**: Update README or docs if needed
+
+## Code Style
+
+- Follow the existing code style in the project
+- Use meaningful variable and function names
+- Add comments for complex logic
+- Keep functions small and focused
+
+## Testing
+
+- Run tests before submitting: `[add your test command]`
+- Add tests for new features
+- Ensure all existing tests pass
+
+## Questions?
+
+Feel free to open an issue if you have questions or need help with your contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,186 +4,42 @@
 >
 > You've created a project from the `claude-code-flow` template. **Replace this README** with your project documentation after setup.
 >
-> **Setup Instructions**: Follow [docs/TEMPLATE_SETUP.md](docs/TEMPLATE_SETUP.md) to configure your development environment.
+> **Complete Instructions**: [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md)
 
 ---
 
 ## About This Template
 
-This project uses the **Claude Code Flow** template for structured AI-assisted development. It provides:
-
-- **Manual workflow** - Step-by-step commands (`/research_requirements`, `/create_plan`, `/implement_plan`)
-- **Autonomous workflow** - Ralph Wiggum autonomous loop (`/ralph`) for unattended multi-issue processing
-- **Research → Plan → Implement → Validate** pattern for quality development
-
-## Quick Start
-
-1. **Follow setup guide**: [docs/TEMPLATE_SETUP.md](docs/TEMPLATE_SETUP.md)
-2. **Update this README**: Replace with your project documentation
-3. **Update CLAUDE.md**: Add project-specific conventions
-4. **Create your first issue**: `gh issue create --title "Your first feature"`
-5. **Start developing**: Use `/research_requirements #1` or `/create_plan #1`
+This project uses the **Claude Code Flow** template - a structured workflow for AI-assisted development with manual step-by-step commands or fully autonomous multi-issue processing.
 
 ---
 
 ## Workflow Overview
 
-### Manual Step-by-Step
-
-**Greenfield (new features):**
+**Manual (step-by-step):**
 ```
 /research_requirements → /create_plan → /implement_plan → /validate_plan → /commit
 ```
 
-**Brownfield (existing codebase):**
-```
-/research_codebase → /create_plan → /implement_plan → /validate_plan → /commit
-```
-
-### Autonomous Loop
-
-```
-/ralph              # Process up to 10 issues automatically
-/ralph 5            # Process up to 5 issues
-```
-
-Ralph automatically handles: Research → Plan → Implement → Validate → PR for each issue.
-
----
-
-## Available Commands
-
-### Research Phase
-
-- **`/research_requirements`** - Research requirements and tech choices for new features
-- **`/research_codebase`** - Document existing codebase patterns and architecture
-
-### Planning Phase
-
-- **`/create_plan`** - Create detailed implementation plans with phased approach
-- **`/iterate_plan`** - Update existing plans based on new requirements
-
-### Implementation Phase
-
-- **`/implement_plan`** - Execute plans phase by phase with verification checkpoints
-- **`/validate_plan`** - Validate implementation matches plan (quality gate before commit)
-
-### Commit & PR Phase
-
-- **`/commit`** - Create git commits with user approval
-- **`/autonomous_commit`** - Create commits without approval (for autonomous workflows)
-- **`/describe_pr`** - Generate comprehensive PR descriptions from templates
-
-### Autonomous Workflow
-
-- **`/ralph`** - Autonomous issue processing loop (Research → Plan → Implement → Validate → PR)
-
-### Session Management
-
-- **`/create_handoff`** - Create handoff document for transferring work to another session
-- **`/resume_handoff`** - Resume work from handoff document with context
-
----
-
-## Feature Branch Workflow
-
-All development uses feature branches:
-
+**Autonomous (unattended):**
 ```bash
-# Create feature branch from issue
-git checkout -b feature/42-your-feature-name
-
-# Do your work using Claude Code commands
-/create_plan #42
-/implement_plan thoughts/plans/2026-02-03-gh-42-your-feature.md
-/validate_plan thoughts/plans/2026-02-03-gh-42-your-feature.md
-
-# Commit and create PR
-/commit
-git push -u origin feature/42-your-feature-name
-gh pr create --base main --draft
-/describe_pr
+/ralph                              # Process up to 10 issues automatically
+./ralph-autonomous.sh --monitor     # Launch with live dashboard
 ```
 
-See [docs/TEMPLATE_SETUP.md](docs/TEMPLATE_SETUP.md) for branch protection setup.
-
----
-
-## Documentation
-
-- **[docs/TEMPLATE_SETUP.md](docs/TEMPLATE_SETUP.md)** - Complete setup guide (prerequisites, hooks, branch protection)
-- **[docs/claude-code-workflow-concepts.md](docs/claude-code-workflow-concepts.md)** - Workflow methodology and principles
-- **[CLAUDE.md](CLAUDE.md)** - Instructions for Claude Code (update with your project conventions)
-
----
-
-## Directory Structure
-
-```
-your-project/
-├── .claude/              # Commands, skills, hooks configuration
-├── .ralph/               # Autonomous workflow state
-├── thoughts/             # Research documents and implementation plans
-│   ├── research/         # Requirements and codebase research
-│   ├── plans/            # Implementation plans
-│   └── prs/              # PR descriptions
-├── docs/                 # Documentation
-├── src/                  # YOUR SOURCE CODE (add this)
-├── tests/                # YOUR TESTS (add this)
-└── [your project files]  # YOUR PROJECT STRUCTURE (add this)
-```
-
----
-
-## Using @claude in Pull Requests
-
-After creating PRs, @mention Claude in PR comments for code reviews:
-
-```
-@claude Review this PR for code quality and potential issues
-@claude What do you think about the architecture decisions?
-@claude Are there any edge cases we might have missed?
-```
-
-Claude will respond with feedback and may suggest improvements to `CLAUDE.md` based on patterns it observes.
-
----
-
-## Ralph Autonomous Development
-
-For fully autonomous multi-issue processing:
-
-```bash
-# Using the /ralph command
-/ralph 10              # Process up to 10 issues
-
-# Using the shell script
-./ralph-autonomous.sh --monitor    # Launch with live dashboard
-./ralph-autonomous.sh --dry-run    # Preview without making changes
-```
-
-Ralph automatically:
-1. Selects highest priority open issue
-2. Creates research if missing
-3. Creates plan if missing
-4. Implements the plan
-5. Validates implementation
-6. Creates PR if validation passes
-7. Moves to next issue
-
-See [docs/TEMPLATE_SETUP.md](docs/TEMPLATE_SETUP.md) for GitHub label prerequisites.
+See [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md) for complete documentation.
 
 ---
 
 ## License
 
-[Add your license here]
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ---
 
 ## Contributing
 
-[Add your contribution guidelines here]
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 

--- a/docs/TEMPLATE_INSTRUCTIONS.md
+++ b/docs/TEMPLATE_INSTRUCTIONS.md
@@ -232,7 +232,7 @@ git push origin main
 # remote: error: GH006: Protected branch update failed
 ```
 
-Instead, all work must go through feature branches and pull requests (see [Feature Branch Workflow](../README.md#feature-branch-workflow)).
+Instead, all work must go through feature branches and pull requests (see [Feature Branch Workflow](#feature-branch-workflow) below).
 
 ### Automatic Reviewer Assignment
 
@@ -537,6 +537,214 @@ This creates a feedback loop where Claude Code improves over time - each PR revi
 
 ---
 
+## Command Reference
+
+The workflow provides these commands organized by phase:
+
+### Research Phase
+
+| Command | Purpose |
+|---------|---------|
+| `/research_requirements` | Research requirements and tech choices for new features |
+| `/research_codebase` | Document existing codebase patterns and architecture |
+
+### Planning Phase
+
+| Command | Purpose |
+|---------|---------|
+| `/create_plan` | Create detailed implementation plans with phased approach |
+| `/iterate_plan` | Update existing plans based on new requirements |
+
+### Implementation Phase
+
+| Command | Purpose |
+|---------|---------|
+| `/implement_plan` | Execute plans phase by phase with verification checkpoints |
+| `/validate_plan` | Validate implementation matches plan (quality gate before commit) |
+
+### Commit & PR Phase
+
+| Command | Purpose |
+|---------|---------|
+| `/commit` | Create git commits with user approval |
+| `/autonomous_commit` | Create commits without approval (for autonomous workflows) |
+| `/describe_pr` | Generate comprehensive PR descriptions from templates |
+
+### Autonomous Workflow
+
+| Command | Purpose |
+|---------|---------|
+| `/ralph` | Autonomous issue processing loop (Research → Plan → Implement → Validate → PR) |
+
+### Session Management
+
+| Command | Purpose |
+|---------|---------|
+| `/create_handoff` | Create handoff document for transferring work to another session |
+| `/resume_handoff` | Resume work from handoff document with context |
+
+**Typical workflow:**
+
+**Greenfield (new features):**
+```
+/research_requirements → /create_plan → /implement_plan → /validate_plan → /commit
+```
+
+**Brownfield (existing codebase):**
+```
+/research_codebase → /create_plan → /implement_plan → /validate_plan → /commit
+```
+
+See [CLAUDE.md](../CLAUDE.md) for workflow guidance and the main [README.md](../README.md) for quick reference.
+
+---
+
+## Feature Branch Workflow
+
+All development work should be done on feature branches. Here's the typical workflow:
+
+```bash
+# Create feature branch from issue
+git checkout -b feature/42-your-feature-name
+
+# Do your work using Claude Code commands
+/create_plan #42
+/implement_plan thoughts/plans/2026-02-03-gh-42-your-feature.md
+/validate_plan thoughts/plans/2026-02-03-gh-42-your-feature.md
+
+# Commit and create PR
+/commit
+git push -u origin feature/42-your-feature-name
+gh pr create --base main --draft
+/describe_pr
+```
+
+**Branch naming convention:**
+```
+feature/<issue-number>-<brief-description>
+```
+
+Examples:
+- `feature/42-add-authentication`
+- `feature/7-configurable-system-prompt`
+
+---
+
+## Directory Structure
+
+After creating a project from this template, you'll have this structure:
+
+```
+your-project/
+├── .claude/              # Commands, skills, hooks configuration
+├── .ralph/               # Autonomous workflow state
+├── thoughts/             # Research documents and implementation plans
+│   ├── research/         # Requirements and codebase research
+│   ├── plans/            # Implementation plans
+│   └── prs/              # PR descriptions
+├── docs/                 # Documentation
+├── src/                  # YOUR SOURCE CODE (add this)
+├── tests/                # YOUR TESTS (add this)
+└── [your project files]  # YOUR PROJECT STRUCTURE (add this)
+```
+
+**What's included:**
+- `.claude/` - Workflow commands and configuration
+- `.ralph/` - Autonomous workflow state tracking
+- `thoughts/` - Research and planning artifacts
+- `docs/` - Template documentation
+
+**What you add:**
+- Your source code (`src/` or your preferred structure)
+- Your tests (`tests/` or your preferred location)
+- Your dependencies (`pyproject.toml`, `package.json`, etc.)
+- Your build/run scripts
+
+---
+
+## Using @claude in Pull Requests
+
+After creating PRs, you can @mention Claude in PR comments for code reviews. Claude will respond using your Claude Code Max subscription.
+
+**Example interactions:**
+
+```
+@claude Review this PR for code quality and potential issues
+```
+
+```
+@claude What do you think about the architecture decisions?
+```
+
+```
+@claude Are there any edge cases we might have missed in the validation logic?
+```
+
+```
+@claude Suggest improvements to CLAUDE.md based on patterns you see
+```
+
+**What happens:**
+1. You add a comment mentioning @claude
+2. The GitHub Action triggers automatically (see [Setting Up Claude PR Reviews](#setting-up-claude-pr-reviews))
+3. Claude reviews your code and responds with feedback
+4. Claude may suggest updates to `CLAUDE.md` for future improvements
+
+This creates a feedback loop where Claude Code improves over time - each PR review can result in better instructions for future sessions.
+
+---
+
+## Ralph Autonomous Development
+
+For fully autonomous multi-issue processing, use the `/ralph` command or `ralph-autonomous.sh` shell script.
+
+### Using Ralph with Live Monitor
+
+Launch Ralph with a live monitoring dashboard:
+
+```bash
+# Launch with live monitoring dashboard
+./ralph-autonomous.sh --monitor
+
+# The dashboard shows:
+# - Left pane: Ralph execution logs (research, planning, implementation)
+# - Right pane: Live status, task queue, API limits, recent activity
+#
+# Controls:
+# - Ctrl+B then D: Detach (Ralph keeps running in background)
+# - Ctrl+B then arrow keys: Switch between panes
+
+# Later, check on progress
+./ralph-autonomous.sh --status
+
+# Or reattach to see live dashboard
+tmux attach -t ralph-monitor-<session-id>
+
+# Preview before running
+./ralph-autonomous.sh --dry-run        # See what would happen without making changes
+```
+
+### How Ralph Works
+
+Ralph automatically processes issues end-to-end:
+
+1. Selects highest priority open issue
+2. Creates research if missing (`/research_requirements`)
+3. Creates plan if missing (`/create_plan`)
+4. Implements the plan (`/implement_plan`)
+5. Validates implementation (`/validate_plan`)
+6. Creates PR if validation passes
+7. Moves to next issue
+
+**Prerequisites:**
+- GitHub labels must exist (see label setup in Branch Protection section)
+- Branch protection configured (prevents direct commits to main)
+
+**Quality Gate:**
+Ralph only creates commits and PRs for implementations that pass validation. Failed validations are flagged for human review rather than attempting automated fixes.
+
+---
+
 ## Next Steps
 
 After completing this setup:
@@ -546,4 +754,4 @@ After completing this setup:
 3. **Create your first issue** - Use GitHub issues to track work
 4. **Start the workflow** - Use `/research_requirements` or `/create_plan` to begin
 
-See the main [README.md](../README.md) for workflow documentation and command reference.
+See the main [README.md](../README.md) for workflow overview.


### PR DESCRIPTION
## Problem

The README for projects created from the template contained too much instructional content:

- **124 lines** of commands, directory structure, @claude usage, Ralph details
- Users would delete this content when replacing README with their project docs
- Instructional content belongs in a setup/usage guide, not a README placeholder
- `TEMPLATE_SETUP.md` name didn't convey it also covers usage/workflow

## Solution

This PR creates a clean separation between what users see vs. template instructions:

### 1. Ultra-Minimal README (124 → 46 lines, 63% reduction)

**Keeps:**
- ⚠️ Warning banner with link to instructions
- Brief "About This Template" (2 lines)
- Workflow overview (command chains only)
- License and Contributing links

**Removes:**
- Command reference → moved to TEMPLATE_INSTRUCTIONS.md
- Directory structure → moved to TEMPLATE_INSTRUCTIONS.md
- @claude usage examples → moved to TEMPLATE_INSTRUCTIONS.md
- Ralph detailed documentation → moved to TEMPLATE_INSTRUCTIONS.md

### 2. Comprehensive Template Guide (642 → 757 lines)

**Renamed:** `TEMPLATE_SETUP.md` → `TEMPLATE_INSTRUCTIONS.md`

**Why rename?** Better reflects dual purpose:
- Setup (prerequisites, branch protection, hooks)
- Usage (commands, workflow, @claude, Ralph)

**Added sections:**
- Directory Structure (with explanations of what's included vs. what to add)
- Using @claude in Pull Requests (detailed examples and workflow)
- Ralph Autonomous Development (monitor mode, how it works, prerequisites)

### 3. Standard Open Source Files

**LICENSE**
- MIT License with placeholders for year and copyright holder
- Users can customize or replace with their preferred license

**CONTRIBUTING.md**
- Fork and clone workflow
- Feature branch guidelines
- PR submission process
- Code style and testing notes

## Benefits

✅ **README is now a true placeholder** - 46 lines users actually replace  
✅ **Single source of truth** - TEMPLATE_INSTRUCTIONS.md covers everything  
✅ **Better naming** - "Instructions" conveys setup + usage  
✅ **Professional setup** - LICENSE and CONTRIBUTING.md included  
✅ **Clearer onboarding** - Users immediately know what to do  

## Testing

After merging, when users click "Use this template":

1. They see minimal README with clear warning
2. Single link to comprehensive instructions
3. Standard LICENSE and CONTRIBUTING files ready to customize

No functional changes - purely documentation restructure.