### PR TITLE
Fix ungraceful exit when Ralph runs out of issues

### DIFF
--- a/scripts/ralph-autonomous.sh
+++ b/scripts/ralph-autonomous.sh
@@ -340,8 +340,7 @@ while [ "$ISSUE_ITERATION" -lt "$MAX_ISSUE_ITERATIONS" ]; do
     # ========================================================================
     log_phase "Step 1: Selecting next issue"
 
-    ISSUE=$(select_next_issue)
-    if [ $? -ne 0 ] || [ -z "$ISSUE" ]; then
+    if ! ISSUE=$(select_next_issue) || [ -z "$ISSUE" ]; then
         log_info "No more issues to process"
         break
     fi


### PR DESCRIPTION
## Summary
- `set -euo pipefail` caused the script to crash on `ISSUE=$(select_next_issue)` when that function returned exit code 1 (no issues found)
- The ERR trap fired before the subsequent `$? -ne 0` check could handle it gracefully, producing spurious `[ERROR]` output and a non-zero exit code
- Fixed by restructuring to `if ! ISSUE=$(select_next_issue) || [ -z "$ISSUE" ]` — bash does not apply `set -e` to commands in an `if` condition

## Test plan
- [ ] Run Ralph against a repo with no open issues — should print "No more issues to process" and exit 0 cleanly, not show `[ERROR]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)