### PR TITLE
Add AGENTS.md baseline and trim CLAUDE.md (T1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Ralph logs
 logs/
 
+# Local research / implementation tracker (working doc, intentionally not committed)
+flow/research/2026-05-21-agentic-coding-state-of-the-art.md
+
 # Python
 __pycache__/
 *.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md
+
+Project instructions for any AI coding agent (Claude Code, OpenAI Codex, GitHub Copilot CLI, Cursor, Gemini CLI, and other AGENTS.md-compatible tools). This file holds the tool-agnostic rules. Tool-specific notes live in that tool's own file; for Claude Code that is [CLAUDE.md](CLAUDE.md), which imports this file.
+
+## Project overview
+
+A template repository for an advanced, staged agentic-coding workflow: research, then plan, then implement, then validate, resetting context between stages. See [README.md](README.md) and [docs/claude-code-workflow-concepts.md](docs/claude-code-workflow-concepts.md).
+
+## Critical: feature-branch requirement
+
+**Never make changes directly on the `main` branch. No exceptions.**
+
+- Create a feature branch before generating or modifying ANY file: code, tests, docs, or workflow artifacts under `flow/`.
+- Every change reaches `main` through a pull request, never a direct commit.
+- Before starting any step that writes files (research, planning, implementation, validation):
+  1. Check the current branch: `git branch --show-current`
+  2. If on `main`, create a feature branch immediately: `git checkout -b feature/<name>`
+  3. Only proceed once on a feature branch.
+- If you find yourself on `main` with changes, stop, create a feature branch, and move the changes there before continuing.
+
+Why: `main` must stay stable and deployable, every change needs review, and accidental `main` commits disrupt the workflow.
+
+## Branch naming
+
+- Features: `feature/<issue-number>-<brief-description>`
+- Bug fixes: `bugfix/<issue-number>-<brief-description>`
+- Always branch from `main`; never commit to `main` directly.
+
+## Workflow: research, plan, implement, validate
+
+Stage the work and reset context between stages. Each stage leaves a durable artifact under `flow/`:
+
+1. **Research**: understand before changing. Output a markdown file in [flow/research/](flow/research/).
+2. **Plan**: write an implementation plan before coding. Output a markdown file in [flow/plans/](flow/plans/).
+3. **Implement**: execute the plan in phases, pausing for verification between phases.
+4. **Validate**: a quality gate before committing. Run the existing test suite, confirm the implementation matches the plan, and catch issues before they reach version control.
+
+Pause for human review at the research and plan boundaries; those are the highest-leverage review points.
+
+## Project conventions
+
+Fill in as the project gains them (package manager, formatters and linters, testing approach). Keep entries specific and load-bearing.
+
+## Documentation conventions
+
+- Use navigable links for file references: `[filename](path/to/file)`, not bare backticks.
+- Reference code with line numbers: `path/to/file.ts:42`; use `#L50-L75` for ranges in links.
+- Keep instruction files (this file and CLAUDE.md) lean and hand-written, roughly 150 to 200 lines maximum. Generic or auto-generated guidance measurably reduces task success, so write only specific, load-bearing rules.
+
+## GitHub issue conventions
+
+- Use navigable links for file references in issues, not just code-highlighted text.
+  - Good: `[config.py](src/backend/config.py)` (clickable)
+  - Avoid: `` `config.py` `` (highlighted but not navigable)
+- Link formats: relative `[config.py](src/backend/config.py)`; with line `[config.py:50](src/backend/config.py#L50)`; with range `[config.py:50-75](src/backend/config.py#L50-L75)`.
+
+## GitHub issue label lifecycle
+
+Each workflow step updates issue labels to track progress:
+
+```
+New issue
+  ↓ research step
+research-in-progress → research-complete
+  ↓ planning step
+planning-in-progress → ready-for-dev
+  ↓ implementation step
+in-progress
+  ↓ validation (on failure) OR PR creation (on success)
+validation-failed OR pr-submitted
+```
+
+Label meanings:
+- `research-in-progress`: research underway
+- `research-complete`: research done, ready for planning
+- `planning-in-progress`: plan being created
+- `ready-for-dev`: has an approved plan, ready to implement
+- `in-progress`: development underway
+- `validation-failed`: implementation failed validation
+- `implementation-failed`: implementation could not be completed
+- `pr-submitted`: PR created, awaiting review
+
+## Build and test commands
+
+```bash
+# No build/test commands yet - this is a template repository.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,140 +1,25 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with this repository.
+@AGENTS.md
 
-## Project Overview
+Claude-Code-specific guidance. The shared, tool-agnostic project rules live in [AGENTS.md](AGENTS.md), imported above and expanded into context automatically at session start.
 
-This is a template repository for setting up an advanced Claude Code workflow. See [`README.md`](README.md) for setup instructions.
+## Workflow commands
 
-## ⚠️ CRITICAL: Feature Branch Requirement ⚠️
+Each workflow stage in [AGENTS.md](AGENTS.md) is invoked through a slash command defined in [.claude/commands/](.claude/commands/). These commands create the `flow/` artifacts and, when given a GitHub issue URL or number, update the issue labels automatically.
 
-**NEVER MAKE CODE CHANGES DIRECTLY ON THE MAIN BRANCH**
+| Stage | Command | Artifact |
+|---|---|---|
+| Research (requirements) | [`/research_requirements`](.claude/commands/research_requirements.md) | `flow/research/` |
+| Research (codebase) | [`/research_codebase`](.claude/commands/research_codebase.md) | `flow/research/` |
+| Plan | [`/create_plan <issue URL>`](.claude/commands/create_plan.md) | `flow/plans/` |
+| Implement | [`/implement_plan <plan path>`](.claude/commands/implement_plan.md) | code, tests |
+| Validate | [`/validate_plan <plan path>`](.claude/commands/validate_plan.md) | quality gate |
+| PR description | [`/describe_pr`](.claude/commands/describe_pr.md) | `flow/prs/` |
+| PR feedback | [`/handle_pr_feedback`](.claude/commands/handle_pr_feedback.md) | code, plan updates |
 
-This is an **absolute requirement** with **NO EXCEPTIONS**:
+See [.claude/commands/](.claude/commands/) for the full set (including `/commit`, `/iterate_plan`, `/create_handoff`, and `/resume_handoff`). Run commands on a feature branch and pause for manual verification between implementation phases.
 
-- **ALWAYS create a feature branch** before making ANY code changes
-- **NEVER commit directly to main** - all changes must go through pull requests
-- **Feature branch naming**: Use descriptive names like `feature/<issue-number>-<brief-description>` or `bugfix/<issue-number>-<brief-description>`
-- **Before starting ANY workflow step** (research, planning, implementation, validation, etc.):
-  1. Check current branch with `git branch --show-current`
-  2. If on main, **IMMEDIATELY** create a feature branch: `git checkout -b feature/<name>`
-  3. Only proceed with changes once on a feature branch
+## Lessons learned
 
-**This applies to ALL workflow commands:**
-- `/research_requirements` - creates markdown files in flow/research/
-- `/research_codebase` - creates markdown files in flow/research/
-- `/create_plan` - creates markdown files in flow/plans/
-- `/implement_plan` - creates/modifies code, tests, and other files
-- `/validate_plan` - may modify files during validation fixes
-- `/describe_pr` - creates markdown files in flow/prs/
-- **ALL of these generate artifacts and must be done on a feature branch**
-
-**Why this matters:**
-- Main branch must always remain stable and deployable
-- All changes require code review via pull requests
-- CI/CD pipelines expect this branching model
-- Accidental main branch commits disrupt the workflow
-
-**If you find yourself on main branch**: STOP immediately, create a feature branch, and move any changes there before proceeding.
-
-## Workflow
-
-Follow the **Research → Plan → Implement → Validate** pattern:
-
-1. **Research first**: Understand before changing
-   - `/research_requirements` for new projects or features
-
-2. **Plan before coding**: Create implementation plans
-   - `/create_plan <GitHub issue URL>`
-   - Plans live in [`flow/plans/`](flow/plans/)
-
-3. **Implement with verification**: Execute plans phase by phase
-   - `/implement_plan <plan path>`
-   - Pause for manual verification between phases
-
-4. **Validate before committing**: Quality gate to catch issues
-   - `/validate_plan <plan path>`
-   - Ensures tests pass and implementation matches plan
-   - Prevents broken code from entering version control
-
-## Development Conventions
-
-### Branch Naming
-- **Feature branches**: `feature/<issue-number>-<brief-description>`
-- **Bug fixes**: `bugfix/<issue-number>-<brief-description>`
-- **Always** branch from main
-- **Never** commit directly to main
-
-### Other Conventions
-<!-- Add your project-specific conventions here -->
-<!-- Examples:
-- Package manager: npm, uv, cargo, go mod, etc.
-- Code style: formatters, linters
-- Testing approach: TDD, integration tests, etc.
--->
-
-## Documentation Conventions
-
-When writing or editing documentation:
-
-- **Always use navigable links** for file references: `[filename](path/to/file)` not just backticks
-- **Link to sections** when referencing commands: `[/command](#command)` not just backticks
-- **Include line numbers** when referencing code: `path/to/file.ts:42`
-- **Keep CLAUDE.md lean**: ~150-200 instructions max for consistent following
-
-## GitHub Issue Conventions
-
-When creating or editing GitHub issues:
-
-- **Use navigable links** for file references, not just code-highlighted text:
-  - ✅ Good: `[prompts.yaml](src/prompts.yaml)` - clickable link
-  - ❌ Bad: `` `prompts.yaml` `` - just highlighted, not navigable
-- **Link formats**:
-  - Relative path: `[config.py](src/backend/config.py)`
-  - With line numbers: `[config.py:50](src/backend/config.py#L50)`
-  - With line range: `[config.py:50-75](src/backend/config.py#L50-L75)`
-- **Benefits**: Makes issues more actionable by allowing direct navigation to referenced code
-
-## GitHub Issue Label Lifecycle
-
-Workflow commands automatically update issue labels to track progress:
-
-**Label progression:**
-```
-New Issue
-  ↓ /research_requirements or /research_codebase
-[research-in-progress] → [research-complete]
-  ↓ /create_plan
-[planning-in-progress] → [ready-for-dev]
-  ↓ /implement_plan
-[in-progress]
-  ↓ /validate_plan (on failure) OR /describe_pr (on success)
-[validation-failed] OR [pr-submitted]
-```
-
-**Label meanings:**
-- `research-in-progress` - Research actively underway
-- `research-complete` - Research done, ready for planning
-- `planning-in-progress` - Implementation plan being created
-- `ready-for-dev` - Has approved plan, ready to implement
-- `in-progress` - Development actively underway
-- `validation-failed` - Implementation failed validation checks
-- `implementation-failed` - Implementation could not be completed
-- `pr-submitted` - PR created, awaiting review
-
-**Important:** Labels update automatically when using workflow commands with GitHub issue URLs/numbers
-
-## Reference Documents
-
-- [`docs/claude-code-workflow-concepts.md`](docs/claude-code-workflow-concepts.md) - Workflow methodology and principles
-
-## Lessons Learned
-
-<!-- Add lessons here as the project develops -->
-<!-- Example: "Don't use X approach because Y" -->
-
-## Build & Test Commands
-
-```bash
-# No build/test commands yet - this is a template repository
-```
+<!-- Add Claude-Code-specific lessons here as the project develops. -->


### PR DESCRIPTION
## Summary

Introduce a tool-agnostic `AGENTS.md` as the universal project-instruction baseline and reduce `CLAUDE.md` to a thin `@AGENTS.md` import plus Claude-only extras. The template's rules become portable to any AGENTS.md-compatible agent (Copilot CLI, Codex, Cursor, Gemini), while Claude Code still sees the full ruleset through the import. Implements tracker item T1.1.

## Changes

- Add `AGENTS.md` with the tool-agnostic rules: feature-branch requirement, branch naming, the research/plan/implement/validate workflow and its `flow/` artifacts, documentation and GitHub issue conventions, the issue label lifecycle, and build/test commands.
- Trim `CLAUDE.md` (141 lines down to ~25) to the `@AGENTS.md` import plus a Claude-only slash-command-to-stage mapping table; no content duplication.
- Ignore the local research/tracker working doc in `.gitignore`.

## Test Plan

- [ ] In Claude Code, confirm the one-time `@AGENTS.md` import approval prompt appears, and once approved the feature-branch and workflow rules are in context.
- [ ] Confirm `AGENTS.md` renders correctly and its relative links resolve.
- [ ] Confirm `git status` does not surface the gitignored research doc.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: template repo, no test suite)
- [x] Documentation updated (AGENTS.md added, CLAUDE.md updated)

## Context

- Verified against official GitHub docs that Copilot CLI reads `AGENTS.md` (with precedence) and `CLAUDE.md`, and loads skills from `.claude/skills/`.
- Heads-up: the first `@AGENTS.md` import triggers a one-time approval dialog in Claude Code; declining it disables imports. A README note is a sensible follow-up.
- Next in the evolution: T2.2 (migrate the workflow commands to the Agent Skills standard).
