### PR TITLE
Migrate workflow commands to .claude/skills/ as Agent Skills (T2.2)

### DIFF
--- a/.claude/skills/autonomous-commit/SKILL.md
+++ b/.claude/skills/autonomous-commit/SKILL.md
@@ -1,5 +1,7 @@
 ---
-description: Autonomously create git commits without user approval (for Ralph workflow)
+name: autonomous-commit
+description: Create git commits autonomously without user approval, for the Ralph autonomous loop. Explicit-only command; run only when invoked via /autonomous-commit, never autonomously in interactive use.
+disable-model-invocation: true
 ---
 
 # Autonomous Commit

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,5 +1,7 @@
 ---
-description: Create git commits with user approval and no Claude attribution
+name: commit
+description: Stage and create git commits after showing a commit plan, with no AI attribution. Explicit-only; run only when the user invokes /commit or asks to commit, never autonomously.
+disable-model-invocation: true
 ---
 
 # Commit Changes

--- a/.claude/skills/create-handoff/SKILL.md
+++ b/.claude/skills/create-handoff/SKILL.md
@@ -1,5 +1,7 @@
 ---
-description: Create handoff document for transferring work to another session
+name: create-handoff
+description: Write a structured handoff document under flow/handoffs/ to transfer work to another session. Explicit-only; run only when invoked via /create-handoff or the user asks for a handoff.
+disable-model-invocation: true
 ---
 
 # Create Handoff
@@ -71,14 +73,14 @@ Once this is completed, you should respond to the user with:
 ```
 Handoff created! You can resume from this handoff in a new session with:
 
-/resume_handoff <path/to/handoff.md>
+/resume-handoff <path/to/handoff.md>
 ```
 
 For example:
 ```
 Handoff created! You can resume from this handoff in a new session with:
 
-/resume_handoff flow/handoffs/gh-123/2025-01-08_13-44-55_implement-streaming-api.md
+/resume-handoff flow/handoffs/gh-123/2025-01-08_13-44-55_implement-streaming-api.md
 ```
 
 ---

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
-description: Create detailed implementation plans with thorough research and iteration
+name: create-plan
+description: Research the codebase and author a phased implementation plan under flow/plans/ from a GitHub issue or task. Explicit workflow command; run only when invoked via /create-plan or explicitly asked, never autonomously.
+argument-hint: [github-issue-url-or-number]
 model: opus
+disable-model-invocation: true
 ---
 
 # Implementation Plan
@@ -16,7 +19,7 @@ You are tasked with creating detailed implementation plans through an interactiv
 - **NO** class definitions
 - **NO** configuration file contents
 
-Instead, describe **what** each file/component should do, not **how** it should be coded. The actual code is written during `/implement_plan`.
+Instead, describe **what** each file/component should do, not **how** it should be coded. The actual code is written during `/implement-plan`.
 
 **Allowed in plans:**
 - Shell commands for verification (e.g., `curl`, `uv run`, `pytest`)
@@ -142,8 +145,8 @@ Please provide:
 
 I'll analyze this information and work with you to create a comprehensive plan.
 
-Tip: You can invoke this command with a GitHub issue: `/create_plan #123` or `/create_plan https://github.com/owner/repo/issues/123`
-For deeper analysis, try: `/create_plan think deeply about #123`
+Tip: You can invoke this command with a GitHub issue: `/create-plan #123` or `/create-plan https://github.com/owner/repo/issues/123`
+For deeper analysis, try: `/create-plan think deeply about #123`
 ```
 
 Then wait for the user's input.
@@ -348,7 +351,7 @@ After structure approval:
 - [Responsibility 1]
 - [Responsibility 2]
 
-> **Remember**: Describe what the file should do, not the actual code. Implementation happens in `/implement_plan`.
+> **Remember**: Describe what the file should do, not the actual code. Implementation happens in `/implement-plan`.
 
 ### Step 3: Verify
 
@@ -445,7 +448,7 @@ After structure approval:
    - Plans describe WHAT to build, not HOW to code it
    - Never include code snippets for files to be created
    - Describe responsibilities and behaviors, not implementations
-   - Code belongs in `/implement_plan`, not here
+   - Code belongs in `/implement-plan`, not here
 
 2. **Test-Driven Development**:
    - Every phase must write tests BEFORE implementation
@@ -580,16 +583,16 @@ tasks = [
 ## Example Interaction Flow
 
 ```
-User: /create_plan #1
+User: /create-plan #1
 Assistant: Let me fetch that GitHub issue and understand what we're building...
 
 [Fetches issue with gh issue view 1]
 
-Based on the issue, I understand we need to create a /research_requirements command for greenfield projects. Let me research the codebase to understand the existing patterns...
+Based on the issue, I understand we need to create a /research-requirements command for greenfield projects. Let me research the codebase to understand the existing patterns...
 
 [Spawns research agents]
 
-I've found the existing research_codebase.md command which follows a specific pattern. Before I start planning, I have some questions...
+I've found the existing research-codebase skill which follows a specific pattern. Before I start planning, I have some questions...
 
 [Interactive process continues...]
 ```

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -1,5 +1,7 @@
 ---
-description: Generate comprehensive PR descriptions following repository templates
+name: describe-pr
+description: Generate a PR description from the repo template, save it under flow/prs/, and update the live PR. Explicit-only; run only when invoked via /describe-pr or the user asks to describe a PR.
+disable-model-invocation: true
 ---
 
 # Generate PR Description

--- a/.claude/skills/handle-pr-feedback/SKILL.md
+++ b/.claude/skills/handle-pr-feedback/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Handle PR feedback from @claude reviews - update plan and implement changes
+name: handle-pr-feedback
+description: Fetch PR review feedback, implement the requested changes, commit, push, and re-request review. Explicit-only; run only when invoked via /handle-pr-feedback or explicitly asked.
+argument-hint: [pr-number]
+disable-model-invocation: true
 ---
 
 # Handle PR Feedback
@@ -9,9 +12,9 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 ## Command Usage
 
 ```bash
-/handle_pr_feedback <pr-number>
+/handle-pr-feedback <pr-number>
 # Or auto-detect from current branch:
-/handle_pr_feedback
+/handle-pr-feedback
 ```
 
 ## Steps to Follow
@@ -225,7 +228,7 @@ Show the user:
 📤 Pushed to: <branch-name>
 💬 Re-review requested from @claude
 
-Next: Wait for @claude's re-review, or run `/handle_pr_feedback` again if more feedback arrives.
+Next: Wait for @claude's re-review, or run `/handle-pr-feedback` again if more feedback arrives.
 ```
 
 ## Important Notes
@@ -261,7 +264,7 @@ Next: Wait for @claude's re-review, or run `/handle_pr_feedback` again if more f
 
 ```bash
 # User runs command
-/handle_pr_feedback 42
+/handle-pr-feedback 42
 
 # Output:
 📥 Fetching PR #42 feedback...

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Implement technical plans from flow/plans with verification
+name: implement-plan
+description: Execute an implementation plan from flow/plans/ phase by phase, pausing for verification between phases. Explicit workflow command; run only when invoked via /implement-plan or explicitly asked, never autonomously.
+argument-hint: [plan-file-path]
+disable-model-invocation: true
 ---
 
 # Implement Plan

--- a/.claude/skills/iterate-plan/SKILL.md
+++ b/.claude/skills/iterate-plan/SKILL.md
@@ -1,6 +1,9 @@
 ---
-description: Iterate on existing implementation plans with thorough research and updates
+name: iterate-plan
+description: Revise an existing implementation plan in flow/plans/ based on feedback, researching when needed. Explicit-only; run only when invoked via /iterate-plan or explicitly asked.
+argument-hint: [plan-file-path]
 model: opus
+disable-model-invocation: true
 ---
 
 # Iterate Implementation Plan
@@ -221,13 +224,13 @@ When spawning research sub-tasks:
 
 **Scenario 1: User provides everything upfront**
 ```
-User: /iterate_plan flow/plans/2025-10-16-feature.md - add phase for error handling
+User: /iterate-plan flow/plans/2025-10-16-feature.md - add phase for error handling
 Assistant: [Reads plan, researches error handling patterns, updates plan]
 ```
 
 **Scenario 2: User provides just plan file**
 ```
-User: /iterate_plan flow/plans/2025-10-16-feature.md
+User: /iterate-plan flow/plans/2025-10-16-feature.md
 Assistant: I've found the plan. What changes would you like to make?
 User: Split Phase 2 into two phases - one for backend, one for frontend
 Assistant: [Proceeds with update]
@@ -235,7 +238,7 @@ Assistant: [Proceeds with update]
 
 **Scenario 3: User provides no arguments**
 ```
-User: /iterate_plan
+User: /iterate-plan
 Assistant: Which plan would you like to update? Please provide the path...
 User: flow/plans/2025-10-16-feature.md
 Assistant: I've found the plan. What changes would you like to make?

--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -1,6 +1,9 @@
 ---
-description: Document codebase as-is with flow directory for historical context
+name: research-codebase
+description: Document the codebase as-is via parallel read-only sub-agents and write findings under flow/research/. Explicit workflow command; run only when invoked via /research-codebase or explicitly asked.
+argument-hint: [github-issue-url-or-question]
 model: opus
+disable-model-invocation: true
 ---
 
 # Research Codebase

--- a/.claude/skills/research-requirements/SKILL.md
+++ b/.claude/skills/research-requirements/SKILL.md
@@ -1,6 +1,9 @@
 ---
-description: Research requirements, tech choices, and constraints for new projects or features
+name: research-requirements
+description: Research requirements, technology choices, and constraints for a feature or project and write findings under flow/research/. Explicit workflow command; run only when invoked via /research-requirements or explicitly asked.
+argument-hint: [github-issue-url-or-description]
 model: opus
+disable-model-invocation: true
 ---
 
 # Research Requirements
@@ -172,7 +175,7 @@ status: complete
 
 ## Recommended Next Steps
 1. Resolve open questions above
-2. Run `/create_plan` with this research document
+2. Run `/create-plan` with this research document
 ```
 
 ### Step 7: Present and Confirm
@@ -199,7 +202,7 @@ Open questions requiring your input:
 - [Question 1]
 - [Question 2]
 
-Please review the research document. Once you've resolved any open questions, you can proceed with `/create_plan` to design the implementation.
+Please review the research document. Once you've resolved any open questions, you can proceed with `/create-plan` to design the implementation.
 ```
 
 3. **Wait for user confirmation** before any next steps
@@ -216,7 +219,7 @@ Please review the research document. Once you've resolved any open questions, yo
 ### What NOT To Do
 
 - **DO NOT write any implementation code** - this is research only
-- **DO NOT create a plan** - that's `/create_plan`'s job
+- **DO NOT create a plan** - that's `/create-plan`'s job
 - **DO NOT make final technology decisions** - present options with trade-offs
 - **DO NOT skip user confirmation** - always present findings for review
 - **DO NOT pollute main context** - use sub-agents for heavy research
@@ -226,6 +229,6 @@ Please review the research document. Once you've resolved any open questions, yo
 
 ## References
 
-- Pattern reference: [`.claude/commands/research_codebase.md`](.claude/commands/research_codebase.md)
+- Pattern reference: [`.claude/skills/research-codebase/SKILL.md`](.claude/skills/research-codebase/SKILL.md)
 - Workflow concepts: [`docs/claude-code-workflow-concepts.md`](docs/claude-code-workflow-concepts.md)
 - Output directory: `flow/research/`

--- a/.claude/skills/resume-handoff/SKILL.md
+++ b/.claude/skills/resume-handoff/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Resume work from handoff document with context analysis and validation
+name: resume-handoff
+description: Resume work from a handoff document, validating current state against it before continuing. Explicit-only; run only when invoked via /resume-handoff or explicitly asked.
+argument-hint: [handoff-file-or-issue-number]
+disable-model-invocation: true
 ---
 
 # Resume work from a handoff document
@@ -36,8 +39,8 @@ I'll help you resume work from a handoff document.
 Which handoff would you like to resume from?
 
 Tip: You can invoke this command directly with:
-- A handoff path: `/resume_handoff flow/handoffs/gh-123/2025-01-08_description.md`
-- A GitHub issue number: `/resume_handoff 123` or `/resume_handoff gh-123`
+- A handoff path: `/resume-handoff flow/handoffs/gh-123/2025-01-08_description.md`
+- A GitHub issue number: `/resume-handoff 123` or `/resume-handoff gh-123`
 ```
 
 Then wait for the user's input.
@@ -198,7 +201,7 @@ Then wait for the user's input.
 ## Example Interaction Flow
 
 ```
-User: /resume_handoff flow/handoffs/gh-42/2025-01-08_handoff.md
+User: /resume-handoff flow/handoffs/gh-42/2025-01-08_handoff.md
 Assistant: Let me read and analyze that handoff document...
 
 [Reads handoff completely]

--- a/.claude/skills/validate-plan/SKILL.md
+++ b/.claude/skills/validate-plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Validate implementation against plan, verify success criteria, identify issues
+name: validate-plan
+description: Validate an implementation against its plan, run verification commands, and report issues before commit. Explicit workflow command; run only when invoked via /validate-plan or explicitly asked.
+argument-hint: [plan-file-path]
+disable-model-invocation: true
 ---
 
 # Validate Plan
@@ -170,11 +173,11 @@ Always verify:
 ## Relationship to Other Commands
 
 Recommended workflow:
-1. `/implement_plan` - Execute the implementation
-2. `/validate_plan` - Verify implementation correctness (quality gate)
+1. `/implement-plan` - Execute the implementation
+2. `/validate-plan` - Verify implementation correctness (quality gate)
 3. Fix any issues found during validation
 4. `/commit` - Create atomic commits for changes (only after validation passes)
-5. `/describe_pr` - Generate PR description
+5. `/describe-pr` - Generate PR description
 
 Validation works best on uncommitted changes, acting as a quality gate before creating commits. This ensures a cleaner git history without "fix validation issues" commits. Use `git diff` to analyze what was implemented.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,21 +4,21 @@
 
 Claude-Code-specific guidance. The shared, tool-agnostic project rules live in [AGENTS.md](AGENTS.md), imported above and expanded into context automatically at session start.
 
-## Workflow commands
+## Workflow skills
 
-Each workflow stage in [AGENTS.md](AGENTS.md) is invoked through a slash command defined in [.claude/commands/](.claude/commands/). These commands create the `flow/` artifacts and, when given a GitHub issue URL or number, update the issue labels automatically.
+Each workflow stage in [AGENTS.md](AGENTS.md) is an explicit-invocation skill in [.claude/skills/](.claude/skills/) (the Agent Skills open standard, so the same files are also picked up by Copilot CLI and other compatible tools). Invoking one creates the `flow/` artifacts and, when given a GitHub issue URL or number, updates the issue labels automatically. Each sets `disable-model-invocation: true`, so it runs only when you invoke it explicitly, never autonomously.
 
 | Stage | Command | Artifact |
 |---|---|---|
-| Research (requirements) | [`/research_requirements`](.claude/commands/research_requirements.md) | `flow/research/` |
-| Research (codebase) | [`/research_codebase`](.claude/commands/research_codebase.md) | `flow/research/` |
-| Plan | [`/create_plan <issue URL>`](.claude/commands/create_plan.md) | `flow/plans/` |
-| Implement | [`/implement_plan <plan path>`](.claude/commands/implement_plan.md) | code, tests |
-| Validate | [`/validate_plan <plan path>`](.claude/commands/validate_plan.md) | quality gate |
-| PR description | [`/describe_pr`](.claude/commands/describe_pr.md) | `flow/prs/` |
-| PR feedback | [`/handle_pr_feedback`](.claude/commands/handle_pr_feedback.md) | code, plan updates |
+| Research (requirements) | [`/research-requirements`](.claude/skills/research-requirements/SKILL.md) | `flow/research/` |
+| Research (codebase) | [`/research-codebase`](.claude/skills/research-codebase/SKILL.md) | `flow/research/` |
+| Plan | [`/create-plan <issue URL>`](.claude/skills/create-plan/SKILL.md) | `flow/plans/` |
+| Implement | [`/implement-plan <plan path>`](.claude/skills/implement-plan/SKILL.md) | code, tests |
+| Validate | [`/validate-plan <plan path>`](.claude/skills/validate-plan/SKILL.md) | quality gate |
+| PR description | [`/describe-pr`](.claude/skills/describe-pr/SKILL.md) | `flow/prs/` |
+| PR feedback | [`/handle-pr-feedback`](.claude/skills/handle-pr-feedback/SKILL.md) | code, plan updates |
 
-See [.claude/commands/](.claude/commands/) for the full set (including `/commit`, `/iterate_plan`, `/create_handoff`, and `/resume_handoff`). Run commands on a feature branch and pause for manual verification between implementation phases.
+See [.claude/skills/](.claude/skills/) for the full set (including `/commit`, `/iterate-plan`, `/create-handoff`, and `/resume-handoff`). Run these on a feature branch and pause for manual verification between implementation phases.
 
 ## Lessons learned
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses the **Claude Code Flow** template - a structured workflow for 
 
 **Manual (step-by-step):**
 
-[/research_requirements](.claude/commands/research_requirements.md) → [/create_plan](.claude/commands/create_plan.md) → [/implement_plan](.claude/commands/implement_plan.md) → [/validate_plan](.claude/commands/validate_plan.md) → [/commit](.claude/commands/commit.md) → Push & PR → [/describe_pr](.claude/commands/describe_pr.md) → Review → [/handle_pr_feedback](.claude/commands/handle_pr_feedback.md) (if needed) → Merge
+[/research-requirements](.claude/skills/research-requirements/SKILL.md) → [/create-plan](.claude/skills/create-plan/SKILL.md) → [/implement-plan](.claude/skills/implement-plan/SKILL.md) → [/validate-plan](.claude/skills/validate-plan/SKILL.md) → [/commit](.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](.claude/skills/handle-pr-feedback/SKILL.md) (if needed) → Merge
 
 **Autonomous (unattended):**
 ```bash

--- a/docs/TEMPLATE_INSTRUCTIONS.md
+++ b/docs/TEMPLATE_INSTRUCTIONS.md
@@ -43,7 +43,7 @@ Before setting up the workflow, ensure you have:
 
 ### GitHub CLI Setup
 
-The workflow uses the GitHub CLI (`gh`) for issue and PR management. This is required for commands like [/create_plan](../.claude/commands/create_plan.md), [/describe_pr](../.claude/commands/describe_pr.md), and others that interact with GitHub.
+The workflow uses the GitHub CLI (`gh`) for issue and PR management. This is required for commands like [/create-plan](../.claude/skills/create-plan/SKILL.md), [/describe-pr](../.claude/skills/describe-pr/SKILL.md), and others that interact with GitHub.
 
 #### Install GitHub CLI
 
@@ -302,18 +302,18 @@ EOFINNER
 
 > **Required for workflow commands:** These labels must exist in your repository for both manual and autonomous workflows.
 
-Labels track issue state through the workflow. Both manual commands (`/research_requirements`, `/create_plan`, `/implement_plan`) and Ralph autonomous script update labels automatically as work progresses.
+Labels track issue state through the workflow. Both manual commands (`/research-requirements`, `/create-plan`, `/implement-plan`) and Ralph autonomous script update labels automatically as work progresses.
 
 | Label | Purpose | Color | Set by |
 |-------|---------|-------|--------|
-| `research-in-progress` | Research actively underway | Blue (`1d76db`) | `/research_requirements`, Ralph |
-| `research-complete` | Research done, ready for planning | Green (`0e8a16`) | `/research_requirements`, Ralph |
-| `planning-in-progress` | Plan being created | Yellow (`fbca04`) | `/create_plan`, Ralph |
-| `ready-for-dev` | Has implementation plan, ready to build | Purple (`5319e7`) | `/create_plan`, Ralph, or manually |
-| `in-progress` | Development actively underway | Red (`d93f0b`) | `/implement_plan`, Ralph |
-| `validation-failed` | Implementation complete but failed validation | Light Purple (`d4c5f9`) | `/validate_plan`, Ralph |
+| `research-in-progress` | Research actively underway | Blue (`1d76db`) | `/research-requirements`, Ralph |
+| `research-complete` | Research done, ready for planning | Green (`0e8a16`) | `/research-requirements`, Ralph |
+| `planning-in-progress` | Plan being created | Yellow (`fbca04`) | `/create-plan`, Ralph |
+| `ready-for-dev` | Has implementation plan, ready to build | Purple (`5319e7`) | `/create-plan`, Ralph, or manually |
+| `in-progress` | Development actively underway | Red (`d93f0b`) | `/implement-plan`, Ralph |
+| `validation-failed` | Implementation complete but failed validation | Light Purple (`d4c5f9`) | `/validate-plan`, Ralph |
 | `implementation-failed` | Implementation could not be completed | Dark Red (`b60205`) | Ralph |
-| `pr-submitted` | PR created, awaiting review | Light Green (`c2e0c6`) | `/describe_pr`, Ralph |
+| `pr-submitted` | PR created, awaiting review | Light Green (`c2e0c6`) | `/describe-pr`, Ralph |
 | `ralph-exempt` | Reserved for human-only work, skipped by Ralph | Gray (`6a737d`) | Manual only |
 | `blocked-by-#N` | Blocked by issue #N (dynamic label) | Any | Manual (see [Dependency Blocking](#dependency-blocking)) |
 
@@ -566,24 +566,24 @@ Edit [.claude/settings.json](../.claude/settings.json) to customize:
 
 ## Important: Command Caching Behavior
 
-Claude Code loads command files ([.claude/commands/](../.claude/commands/)*.md) into memory when a session starts. This means:
+Claude Code loads skill files ([.claude/skills/](../.claude/skills/)*/SKILL.md) into memory when a session starts. This means:
 
-**If you edit a command file during a session, the changes won't take effect until you restart Claude Code.**
+**If you edit a skill file during a session, the changes won't take effect until you restart Claude Code.**
 
 This applies to:
-- Creating new commands
-- Modifying existing commands
-- Renaming or deleting commands
+- Creating new skills
+- Modifying existing skills
+- Renaming or deleting skills
 
 ### Symptoms of Stale Cache
 
-If you edit a command and it still behaves the old way:
+If you edit a skill and it still behaves the old way:
 - The Skill tool loaded the in-memory (stale) version
 - Your file edits are correct on disk but not loaded
 
 ### Solution
 
-Restart your Claude Code session after modifying any files in [.claude/commands/](../.claude/commands/).
+Restart your Claude Code session after modifying any files in [.claude/skills/](../.claude/skills/).
 
 ```bash
 # Exit Claude Code (Ctrl+C or /exit)
@@ -591,7 +591,7 @@ Restart your Claude Code session after modifying any files in [.claude/commands/
 claude
 ```
 
-This ensures all command files are freshly loaded from disk.
+This ensures all skill files are freshly loaded from disk.
 
 ---
 
@@ -669,31 +669,31 @@ The workflow provides these commands organized by phase:
 
 | Command | Purpose |
 |---------|---------|
-| [/research_requirements](../.claude/commands/research_requirements.md) | Research requirements and tech choices for new features |
-| [/research_codebase](../.claude/commands/research_codebase.md) | Document existing codebase patterns and architecture |
+| [/research-requirements](../.claude/skills/research-requirements/SKILL.md) | Research requirements and tech choices for new features |
+| [/research-codebase](../.claude/skills/research-codebase/SKILL.md) | Document existing codebase patterns and architecture |
 
 ### Planning Phase
 
 | Command | Purpose |
 |---------|---------|
-| [/create_plan](../.claude/commands/create_plan.md) | Create detailed implementation plans with phased approach |
-| [/iterate_plan](../.claude/commands/iterate_plan.md) | Update existing plans based on new requirements |
+| [/create-plan](../.claude/skills/create-plan/SKILL.md) | Create detailed implementation plans with phased approach |
+| [/iterate-plan](../.claude/skills/iterate-plan/SKILL.md) | Update existing plans based on new requirements |
 
 ### Implementation Phase
 
 | Command | Purpose |
 |---------|---------|
-| [/implement_plan](../.claude/commands/implement_plan.md) | Execute plans phase by phase with verification checkpoints |
-| [/validate_plan](../.claude/commands/validate_plan.md) | Validate implementation matches plan (quality gate before commit) |
+| [/implement-plan](../.claude/skills/implement-plan/SKILL.md) | Execute plans phase by phase with verification checkpoints |
+| [/validate-plan](../.claude/skills/validate-plan/SKILL.md) | Validate implementation matches plan (quality gate before commit) |
 
 ### Commit & PR Phase
 
 | Command | Purpose |
 |---------|---------|
-| [/commit](../.claude/commands/commit.md) | Create git commits with user approval |
-| [/autonomous_commit](../.claude/commands/autonomous_commit.md) | Create commits without approval (for autonomous workflows) |
-| [/describe_pr](../.claude/commands/describe_pr.md) | Generate comprehensive PR descriptions from templates |
-| [/handle_pr_feedback](../.claude/commands/handle_pr_feedback.md) | Handle @claude PR review feedback - update plan and implement changes |
+| [/commit](../.claude/skills/commit/SKILL.md) | Create git commits with user approval |
+| [/autonomous-commit](../.claude/skills/autonomous-commit/SKILL.md) | Create commits without approval (for autonomous workflows) |
+| [/describe-pr](../.claude/skills/describe-pr/SKILL.md) | Generate comprehensive PR descriptions from templates |
+| [/handle-pr-feedback](../.claude/skills/handle-pr-feedback/SKILL.md) | Handle @claude PR review feedback - update plan and implement changes |
 
 ### Autonomous Workflow
 
@@ -705,18 +705,18 @@ The workflow provides these commands organized by phase:
 
 | Command | Purpose |
 |---------|---------|
-| [/create_handoff](../.claude/commands/create_handoff.md) | Create handoff document for transferring work to another session |
-| [/resume_handoff](../.claude/commands/resume_handoff.md) | Resume work from handoff document with context |
+| [/create-handoff](../.claude/skills/create-handoff/SKILL.md) | Create handoff document for transferring work to another session |
+| [/resume-handoff](../.claude/skills/resume-handoff/SKILL.md) | Resume work from handoff document with context |
 
 **Typical workflow:**
 
 **Greenfield (new features):**
 
-[/research_requirements](../.claude/commands/research_requirements.md) → [/create_plan](../.claude/commands/create_plan.md) → [/implement_plan](../.claude/commands/implement_plan.md) → [/validate_plan](../.claude/commands/validate_plan.md) → [/commit](../.claude/commands/commit.md) → Push & PR → [/describe_pr](../.claude/commands/describe_pr.md) → Review → [/handle_pr_feedback](../.claude/commands/handle_pr_feedback.md) (if needed)
+[/research-requirements](../.claude/skills/research-requirements/SKILL.md) → [/create-plan](../.claude/skills/create-plan/SKILL.md) → [/implement-plan](../.claude/skills/implement-plan/SKILL.md) → [/validate-plan](../.claude/skills/validate-plan/SKILL.md) → [/commit](../.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](../.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](../.claude/skills/handle-pr-feedback/SKILL.md) (if needed)
 
 **Brownfield (existing codebase):**
 
-[/research_codebase](../.claude/commands/research_codebase.md) → [/create_plan](../.claude/commands/create_plan.md) → [/implement_plan](../.claude/commands/implement_plan.md) → [/validate_plan](../.claude/commands/validate_plan.md) → [/commit](../.claude/commands/commit.md) → Push & PR → [/describe_pr](../.claude/commands/describe_pr.md) → Review → [/handle_pr_feedback](../.claude/commands/handle_pr_feedback.md) (if needed)
+[/research-codebase](../.claude/skills/research-codebase/SKILL.md) → [/create-plan](../.claude/skills/create-plan/SKILL.md) → [/implement-plan](../.claude/skills/implement-plan/SKILL.md) → [/validate-plan](../.claude/skills/validate-plan/SKILL.md) → [/commit](../.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](../.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](../.claude/skills/handle-pr-feedback/SKILL.md) (if needed)
 
 ---
 
@@ -834,27 +834,27 @@ flowchart TD
     Start([Create GitHub Issue]) --> Branch[🌿 Create Feature Branch]
     Branch --> Research{New Feature or<br/>Existing Codebase?}
 
-    Research -->|New| ResReq["📋 research_requirements<br/><i>Explore requirements</i>"]
-    Research -->|Existing| ResCB["🔎 research_codebase<br/><i>Understand patterns</i>"]
+    Research -->|New| ResReq["📋 research-requirements<br/><i>Explore requirements</i>"]
+    Research -->|Existing| ResCB["🔎 research-codebase<br/><i>Understand patterns</i>"]
 
-    ResReq --> Plan["📝 create_plan<br/><i>Design approach</i>"]
+    ResReq --> Plan["📝 create-plan<br/><i>Design approach</i>"]
     ResCB --> Plan
 
-    Plan --> Implement["implement_plan<br/><i>Build features</i>"]
-    Implement --> Validate["✓ validate_plan<br/><i>Quality check</i>"]
+    Plan --> Implement["implement-plan<br/><i>Build features</i>"]
+    Implement --> Validate["✓ validate-plan<br/><i>Quality check</i>"]
 
     Validate -->|❌ Failed| Implement
     Validate -->|✅ Passed| Commit["💾 commit<br/><i>Save changes</i>"]
 
     Commit --> Push["Push Branch"]
     Push --> CreatePR["Create Draft PR<br/><i>gh pr create --draft</i>"]
-    CreatePR --> DescribePR["📄 describe_pr<br/><i>Generate description</i>"]
+    CreatePR --> DescribePR["📄 describe-pr<br/><i>Generate description</i>"]
     DescribePR --> Ready["Mark PR Ready<br/><i>gh pr ready</i>"]
 
     Ready --> Review{"🤖 @claude<br/>Review"}
 
     Review -->|✅ Approved| Merge["🎉 Merge PR"]
-    Review -->|🔄 Changes<br/>Requested| Feedback["🔧 handle_pr_feedback<br/><i>Update plan & implement</i>"]
+    Review -->|🔄 Changes<br/>Requested| Feedback["🔧 handle-pr-feedback<br/><i>Update plan & implement</i>"]
 
     Feedback --> Review
 
@@ -897,16 +897,16 @@ gh issue create --title "Add feature X" --body "Description..."
 git checkout -b feature/42-add-feature-x
 
 # 3. Research requirements
-/research_requirements #42
+/research-requirements #42
 
 # 4. Create implementation plan
-/create_plan flow/research/2026-02-03-gh-42-add-feature-x.md
+/create-plan flow/research/2026-02-03-gh-42-add-feature-x.md
 
 # 5. Implement the plan
-/implement_plan flow/plans/2026-02-03-gh-42-add-feature-x.md
+/implement-plan flow/plans/2026-02-03-gh-42-add-feature-x.md
 
 # 6. Validate implementation
-/validate_plan flow/plans/2026-02-03-gh-42-add-feature-x.md
+/validate-plan flow/plans/2026-02-03-gh-42-add-feature-x.md
 
 # 7. Commit changes
 /commit
@@ -923,7 +923,7 @@ gh pr create --base main --draft
 # This creates: feature/42-add-feature-x → main
 
 # 10. Generate comprehensive PR description
-/describe_pr
+/describe-pr
 # - Reads .github/PULL_REQUEST_TEMPLATE.md
 # - Analyzes PR diff and commit history
 # - Generates description following template
@@ -946,16 +946,16 @@ gh issue create --title "Add new endpoint" --body "Description..."
 git checkout -b feature/7-new-endpoint
 
 # 3. Research the codebase
-/research_codebase #7
+/research-codebase #7
 
 # 4. Create implementation plan
-/create_plan flow/research/2026-02-03-gh-7-new-endpoint.md
+/create-plan flow/research/2026-02-03-gh-7-new-endpoint.md
 
 # 5. Implement the plan
-/implement_plan flow/plans/2026-02-03-gh-7-new-endpoint.md
+/implement-plan flow/plans/2026-02-03-gh-7-new-endpoint.md
 
 # 6. Validate implementation
-/validate_plan flow/plans/2026-02-03-gh-7-new-endpoint.md
+/validate-plan flow/plans/2026-02-03-gh-7-new-endpoint.md
 
 # 7. Commit changes
 /commit
@@ -972,7 +972,7 @@ gh pr create --base main --draft
 # This creates: feature/7-new-endpoint → main
 
 # 10. Generate comprehensive PR description
-/describe_pr
+/describe-pr
 # - Reads .github/PULL_REQUEST_TEMPLATE.md
 # - Analyzes PR diff and commit history
 # - Generates description following template
@@ -1006,14 +1006,14 @@ Create a PR for this branch
 
 Claude will use `gh pr create` and prompt you for title and description if needed.
 
-### Using `/describe_pr`
+### Using `/describe-pr`
 
-> Implementation: [`.claude/commands/describe_pr.md`](../.claude/commands/describe_pr.md)
+> Implementation: [`.claude/skills/describe-pr/SKILL.md`](../.claude/skills/describe-pr/SKILL.md)
 
 Generates comprehensive PR descriptions following this repository's template.
 
 ```
-/describe_pr
+/describe-pr
 ```
 
 **What it does:**
@@ -1036,7 +1036,7 @@ gh pr create --base main --title "Add feature X" --body "WIP" --draft
 # Source: Current branch (feature/42-add-feature-x)
 
 # 3. Generate comprehensive description
-/describe_pr
+/describe-pr
 # Reads .github/PULL_REQUEST_TEMPLATE.md
 # Analyzes diff, runs tests
 # Automatically UPDATES the draft PR
@@ -1110,7 +1110,7 @@ Explicit approval/rejection request - useful for autonomous workflows
 # After completing the development workflow (see Step-by-Step Development Workflow):
 # - Implemented plan, committed changes
 # - Pushed feature branch, created draft PR via gh pr create --base main --draft
-# - Ran /describe_pr to generate comprehensive description
+# - Ran /describe-pr to generate comprehensive description
 
 # Get Claude's review in the GitHub PR:
 @claude Review this PR for code quality and potential issues
@@ -1122,12 +1122,12 @@ Explicit approval/rejection request - useful for autonomous workflows
 
 When @claude reviews your PR and suggests changes, you have two options:
 
-**Option 1: Automated (Recommended)** - Use `/handle_pr_feedback`:
+**Option 1: Automated (Recommended)** - Use `/handle-pr-feedback`:
 
 ```bash
-/handle_pr_feedback 42
+/handle-pr-feedback 42
 # Or auto-detect PR from current branch:
-/handle_pr_feedback
+/handle-pr-feedback
 ```
 
 This automatically:
@@ -1138,7 +1138,7 @@ This automatically:
 - Commits and pushes
 - Requests re-review from @claude
 
-See [/handle_pr_feedback](../.claude/commands/handle_pr_feedback.md) for details.
+See [/handle-pr-feedback](../.claude/skills/handle-pr-feedback/SKILL.md) for details.
 
 > **Why update plans?** Implementation plans serve as living documentation of what was built and why. When @claude's review reveals issues or better approaches, these insights should be captured in the plan so it reflects reality, not just original intent. This is especially important for future reference and understanding the evolution of the implementation.
 
@@ -1253,21 +1253,21 @@ flowchart TD
     CheckCircuit -->|OPEN| Halted([⛔ Halted<br/><i>Fix issues & reset</i>])
     CheckCircuit -->|CLOSED| InnerLoop["⟳ Inner Loop<br/>Attempt 1-10"]
 
-    InnerLoop --> Research["📋 Research Phase<br/><i>/research_codebase</i>"]
+    InnerLoop --> Research["📋 Research Phase<br/><i>/research-codebase</i>"]
     Research -->|Missing| CreateResearch["Create research doc"]
     Research -->|Exists| Plan
-    CreateResearch --> Plan["📝 Plan Phase<br/><i>/create_plan</i>"]
+    CreateResearch --> Plan["📝 Plan Phase<br/><i>/create-plan</i>"]
 
     Plan -->|Missing| CreatePlan["Create implementation plan"]
     Plan -->|Exists| Branch
     CreatePlan --> Branch["🌿 Create Feature Branch<br/><i>feature/N-title</i>"]
 
-    Branch --> Implement["⚙️ Implement Phase<br/><i>/implement_plan</i>"]
+    Branch --> Implement["⚙️ Implement Phase<br/><i>/implement-plan</i>"]
 
-    Implement -->|Success| Validate["✓ Validate Phase<br/><i>/validate_plan</i>"]
+    Implement -->|Success| Validate["✓ Validate Phase<br/><i>/validate-plan</i>"]
     Implement -->|Timeout/Error| CheckAttempts
 
-    Validate -->|✅ Passed| Commit["💾 Commit & Push<br/><i>/autonomous_commit</i>"]
+    Validate -->|✅ Passed| Commit["💾 Commit & Push<br/><i>/autonomous-commit</i>"]
     Validate -->|❌ Failed| CheckAttempts{Attempts<br/>< 10?}
 
     CheckAttempts -->|Yes| RetryFresh["🔄 Retry with Fresh Session<br/><i>Compressed feedback</i>"]
@@ -1282,7 +1282,7 @@ flowchart TD
     PollReview --> ReviewDecision{Review<br/>Decision?}
 
     ReviewDecision -->|APPROVED| AutoMerge["🎉 Auto-Merge PR<br/><i>Squash & delete branch</i>"]
-    ReviewDecision -->|CHANGES_REQUESTED| HandleFeedback["🔧 Handle PR Feedback<br/><i>/handle_pr_feedback</i>"]
+    ReviewDecision -->|CHANGES_REQUESTED| HandleFeedback["🔧 Handle PR Feedback<br/><i>/handle-pr-feedback</i>"]
     ReviewDecision -->|TIMEOUT| NeedsHuman["⚠️ Needs Human Review<br/><i>Label & continue</i>"]
 
     HandleFeedback --> ReviewIteration{Iteration<br/>< 3?}
@@ -1364,10 +1364,10 @@ Ralph automatically processes issues end-to-end:
    - **Stage 4: Score Priority** - Analyzes issue titles/descriptions for keywords to assign priority 1-5 (see [Priority Levels](#priority-levels) below)
    - **Stage 5: Sort** - Orders issues by: priority score (1=highest), has plan (`ready-for-dev`), has research (`research-complete`), issue number (older first)
    - **Stage 6: Select** - Picks the top issue from the sorted list
-2. Creates research if missing ([/research_requirements](../.claude/commands/research_requirements.md))
-3. Creates plan if missing ([/create_plan](../.claude/commands/create_plan.md))
-4. Implements the plan ([/implement_plan](../.claude/commands/implement_plan.md))
-5. Validates implementation ([/validate_plan](../.claude/commands/validate_plan.md))
+2. Creates research if missing ([/research-requirements](../.claude/skills/research-requirements/SKILL.md))
+3. Creates plan if missing ([/create-plan](../.claude/skills/create-plan/SKILL.md))
+4. Implements the plan ([/implement-plan](../.claude/skills/implement-plan/SKILL.md))
+5. Validates implementation ([/validate-plan](../.claude/skills/validate-plan/SKILL.md))
 6. Creates PR if validation passes
 7. **Requests @claude review:**
    - Comments on the PR instructing @claude to review and end its response with exactly one of:
@@ -1375,7 +1375,7 @@ Ralph automatically processes issues end-to-end:
      - `**DECISION: CHANGES_REQUESTED**` — changes needed (listed above the decision line)
    - Polls for review completion every 30s (10 minute timeout), scanning for the structured decision line
    - If APPROVED → proceeds to merge
-   - If CHANGES_REQUESTED → uses [/handle_pr_feedback](../.claude/commands/handle_pr_feedback.md):
+   - If CHANGES_REQUESTED → uses [/handle-pr-feedback](../.claude/skills/handle-pr-feedback/SKILL.md):
      - Updates implementation plan with "PR Review Updates" section
      - Implements requested changes
      - Commits and pushes updates
@@ -1544,7 +1544,7 @@ tmux attach -t ralph-monitor-<session-id>
 - ✅ Complete the full loop iteration
 
 **What dry-run DOES NOT do:**
-- ❌ Invoke Claude Code skills (`/research_codebase`, `/create_plan`, `/implement_plan`, `/validate_plan`)
+- ❌ Invoke Claude Code skills (`/research-codebase`, `/create-plan`, `/implement-plan`, `/validate-plan`)
 - ❌ Make API calls to Claude (no cost incurred)
 - ❌ Update GitHub issue labels
 - ❌ Create git commits
@@ -1564,11 +1564,11 @@ tmux attach -t ralph-monitor-<session-id>
 ./scripts/ralph-autonomous.sh --dry-run
 
 # Output shows:
-# [DRY RUN] Would invoke /research_codebase for issue #42
-# [DRY RUN] Would invoke /create_plan for issue #42
+# [DRY RUN] Would invoke /research-codebase for issue #42
+# [DRY RUN] Would invoke /create-plan for issue #42
 # [DRY RUN] Would reset to main and create branch: feature/42-add-feature-x
-# [DRY RUN] Would invoke /implement_plan for flow/plans/...
-# [DRY RUN] Would invoke /validate_plan for flow/plans/...
+# [DRY RUN] Would invoke /implement-plan for flow/plans/...
+# [DRY RUN] Would invoke /validate-plan for flow/plans/...
 # [DRY RUN] Would commit changes and create PR
 ```
 
@@ -1745,7 +1745,7 @@ This template uses a **custom command** instead. Here's why:
 |--------|----------------|-----------------|
 | **Transparency** | Black box - can't see what it does | Full visibility into loop logic |
 | **Integration** | Generic | Uses YOUR GitHub labels, paths, existing commands |
-| **Workflow** | Standalone | Orchestrates `/research_requirements` → `/create_plan` → `/implement_plan` → `/validate_plan` |
+| **Workflow** | Standalone | Orchestrates `/research-requirements` → `/create-plan` → `/implement-plan` → `/validate-plan` |
 | **Quality Gates** | Unknown | Validation before commits, fails gracefully |
 | **Artifacts** | Unknown | Creates `flow/research/` and `flow/plans/` documents |
 | **Customization** | Use as-is | Modify to match your workflow |
@@ -1759,6 +1759,6 @@ After completing this setup:
 1. **Update README.md** - Replace it with your project documentation
 2. **Update CLAUDE.md** - Add project-specific conventions and build commands
 3. **Create your first issue** - Use GitHub issues to track work
-4. **Start the workflow** - Use [/research_requirements](../.claude/commands/research_requirements.md) or [/create_plan](../.claude/commands/create_plan.md) to begin
+4. **Start the workflow** - Use [/research-requirements](../.claude/skills/research-requirements/SKILL.md) or [/create-plan](../.claude/skills/create-plan/SKILL.md) to begin
 
 See the main [README.md](../README.md) for workflow overview.

--- a/scripts/ralph-autonomous.sh
+++ b/scripts/ralph-autonomous.sh
@@ -414,12 +414,12 @@ while [ "$ISSUE_ITERATION" -lt "$MAX_ISSUE_ITERATIONS" ]; do
                 if [ "$DRY_RUN" = false ]; then
                     gh_update_label "$ISSUE" "research-in-progress" ""
 
-                    log_info "Invoking /research_codebase skill in FRESH Claude session..."
+                    log_info "Invoking /research-codebase skill in FRESH Claude session..."
                     increment_rate_limit
                     record_api_call
 
                     # FRESH CLAUDE SESSION - No prior context
-                    # NOTE: Do NOT use slash command syntax (/research_codebase) - causes hang in print mode (GitHub issue #4184)
+                    # NOTE: Do NOT use slash command syntax (/research-codebase) - causes hang in print mode (GitHub issue #4184)
                     PROMPT="You are an autonomous agent. Research GitHub issue #$ISSUE for implementation planning.
 
 CRITICAL: Do NOT use AskUserQuestion. Make all decisions independently.
@@ -459,7 +459,7 @@ Output RESEARCH_COMPLETE when the document is created."
                         continue  # RETRY with fresh session
                     fi
                 else
-                    log_info "[DRY RUN] Would invoke /research_codebase for issue #$ISSUE"
+                    log_info "[DRY RUN] Would invoke /research-codebase for issue #$ISSUE"
                 fi
             fi
         fi
@@ -479,7 +479,7 @@ Output RESEARCH_COMPLETE when the document is created."
         if [ "$DRY_RUN" = false ]; then
             gh_update_label "$ISSUE" "planning-in-progress" "research-complete,ready-for-dev,in-progress"
 
-            log_info "Invoking /create_plan skill in FRESH Claude session..."
+            log_info "Invoking /create-plan skill in FRESH Claude session..."
             increment_rate_limit
             record_api_call
 
@@ -507,7 +507,7 @@ Output RESEARCH_COMPLETE when the document is created."
                 continue  # RETRY with fresh session
             fi
         else
-            log_info "[DRY RUN] Would invoke /create_plan for issue #$ISSUE"
+            log_info "[DRY RUN] Would invoke /create-plan for issue #$ISSUE"
         fi
 
         # ====================================================================
@@ -545,7 +545,7 @@ Output RESEARCH_COMPLETE when the document is created."
         if [ "$DRY_RUN" = false ]; then
             gh_update_label "$ISSUE" "in-progress" "ready-for-dev"
 
-            log_info "Invoking /implement_plan skill in FRESH Claude session..."
+            log_info "Invoking /implement-plan skill in FRESH Claude session..."
             increment_rate_limit
             record_api_call
 
@@ -613,7 +613,7 @@ Output RESEARCH_COMPLETE when the document is created."
                 continue  # RETRY with fresh session
             fi
         else
-            log_info "[DRY RUN] Would invoke /implement_plan for $PLAN_FILE"
+            log_info "[DRY RUN] Would invoke /implement-plan for $PLAN_FILE"
             FILES_CHANGED=5  # Fake for dry run
         fi
 
@@ -630,7 +630,7 @@ Output RESEARCH_COMPLETE when the document is created."
         VALIDATION_PASSED=false
 
         if [ "$DRY_RUN" = false ]; then
-            log_info "Invoking /validate_plan skill in FRESH Claude session..."
+            log_info "Invoking /validate-plan skill in FRESH Claude session..."
             increment_rate_limit
             record_api_call
 
@@ -684,7 +684,7 @@ Output 'VALIDATION PASSED' if all checks pass, or 'VALIDATION FAILED: <reason>' 
                 continue  # RETRY with fresh session and validation feedback
             fi
         else
-            log_info "[DRY RUN] Would invoke /validate_plan for $PLAN_FILE"
+            log_info "[DRY RUN] Would invoke /validate-plan for $PLAN_FILE"
             VALIDATION_PASSED=true
         fi
 
@@ -698,7 +698,7 @@ Output 'VALIDATION PASSED' if all checks pass, or 'VALIDATION FAILED: <reason>' 
 
             if [ "$DRY_RUN" = false ]; then
                 # Commit changes
-                log_info "Invoking /autonomous_commit skill in FRESH Claude session..."
+                log_info "Invoking /autonomous-commit skill in FRESH Claude session..."
                 increment_rate_limit
                 record_api_call
 
@@ -892,8 +892,8 @@ Do not use any other format for the final decision line."
                         if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ]; then
                             log_info "Handling feedback iteration $REVIEW_ITERATION/$MAX_REVIEW_ITERATIONS"
 
-                            # Use /handle_pr_feedback to implement changes
-                            log_info "Invoking /handle_pr_feedback in FRESH Claude session..."
+                            # Use /handle-pr-feedback to implement changes
+                            log_info "Invoking /handle-pr-feedback in FRESH Claude session..."
                             increment_rate_limit
                             record_api_call
 
@@ -939,8 +939,8 @@ After your review, you MUST end your response with exactly one of these lines:
                                     break
                                 fi
                             else
-                                log_error "Failed to execute /handle_pr_feedback"
-                                save_attempt_feedback "$ISSUE" "$ATTEMPT" "pr_feedback" "failed" "Failed to execute handle_pr_feedback command" ""
+                                log_error "Failed to execute /handle-pr-feedback"
+                                save_attempt_feedback "$ISSUE" "$ATTEMPT" "pr_feedback" "failed" "Failed to execute handle-pr-feedback skill" ""
                                 gh_update_label "$ISSUE" "needs-human-review" "pr-submitted"
                                 gh_add_comment "$ISSUE" "⚠️ Failed to process @claude feedback. Needs human review."
                                 break

--- a/scripts/ralph_feedback.sh
+++ b/scripts/ralph_feedback.sh
@@ -109,7 +109,7 @@ build_plan_prompt() {
     local attempt=$2
     local feedback_context="$3"
 
-    # NOTE: Do NOT use slash command syntax (/create_plan) - causes hang in print mode (GitHub issue #4184)
+    # NOTE: Do NOT use slash command syntax (/create-plan) - causes hang in print mode (GitHub issue #4184)
     local base_prompt="You are an autonomous agent. Create an implementation plan for GitHub issue #$issue (attempt $attempt/$MAX_ATTEMPTS_PER_ISSUE).
 
 CRITICAL: Do NOT use AskUserQuestion. Make all decisions independently.
@@ -146,7 +146,7 @@ build_implement_prompt() {
     local plan_file=$3
     local feedback_context="$4"
 
-    # NOTE: Do NOT use slash command syntax (/implement_plan) - causes hang in print mode (GitHub issue #4184)
+    # NOTE: Do NOT use slash command syntax (/implement-plan) - causes hang in print mode (GitHub issue #4184)
     local base_prompt="You are an autonomous agent. Implement the plan for GitHub issue #$issue (attempt $attempt/$MAX_ATTEMPTS_PER_ISSUE).
 
 CRITICAL: Do NOT use AskUserQuestion. Make all decisions independently.


### PR DESCRIPTION
## Summary

Convert the 12 `.claude/commands/*.md` custom commands into the portable Agent Skills standard (`.claude/skills/<name>/SKILL.md`), so the same files are read by Claude Code, GitHub Copilot CLI, and other AGENTS.md-compatible tools. Implements tracker item T2.2 and largely subsumes T2.3.

## Changes

- **Move + rename**: `git mv` each command to `.claude/skills/<name>/SKILL.md`, adopting the standard hyphenated name (`/research_requirements` becomes `/research-requirements`; `/commit` unchanged). History preserved; `.claude/commands/` removed.
- **Frontmatter**: each skill gains `name`, an explicit-trigger `description`, and `disable-model-invocation: true` (explicit-only, and keeps them out of the always-loaded skill-listing budget). `model: opus` preserved on the 4 that set it; `argument-hint` added to the 8 that take input. Bodies unchanged.
- **References updated**: `CLAUDE.md`, `README.md`, `docs/TEMPLATE_INSTRUCTIONS.md` (including the Mermaid workflow diagram and the caching section), and the two Ralph scripts' log strings.

## Cross-tool behavior

- **Claude Code**: explicit `/create-plan`, `/commit`, etc. still work; autonomous firing is blocked.
- **Copilot CLI**: reads the same `.claude/skills/` files. It does not honor `disable-model-invocation`, so the explicit-only intent is carried by the description phrasing (verified against official GitHub docs).
- **Ralph**: functionally unaffected; it inlines phase prompts and never invokes slash commands, so only log strings changed.

## Test Plan

- [ ] Restart Claude Code, then confirm `/commit` and `/create-plan` invoke (guards against edge bug claude-code#26251, where `disable-model-invocation` can suppress `/name`).
- [ ] Run `/doctor` and confirm the skill-listing budget is clean (the 12 explicit-only skills should not count).
- [ ] Confirm the workflow skills do not auto-fire (e.g. a "plan this" prompt should not auto-invoke `/create-plan`).

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: template repo, no test suite)
- [x] Documentation updated (CLAUDE.md, README.md, TEMPLATE_INSTRUCTIONS.md)

## Context

- Standard-compliant hyphenated names match the existing 13 skills and the agentskills.io spec.
- Follows T1.1 (#31). Optional follow-up: a README note about the one-time `@AGENTS.md` import approval prompt.
