### PR TITLE
Add optional cross-vendor review skill with configurable OAuth backends (T1.3)

### DIFF
--- a/.claude/skills/cross-review/SKILL.md
+++ b/.claude/skills/cross-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: cross-review
+description: Run an OPTIONAL, advisory cross-vendor code review of the current branch's diff vs main using a configurable second-opinion backend (Azure Foundry next-gen, GitHub Models, or Copilot CLI - all OAuth, all keyless). Explicit-only; run only when invoked via /cross-review or when the user explicitly asks for a cross-vendor review, never autonomously.
+argument-hint: [profile-name]
+disable-model-invocation: true
+allowed-tools: Bash
+---
+
+# Cross-vendor review
+
+You are running a cross-vendor code review on the current branch's diff vs `main`, using the reviewer profile the user named (or the default from `profiles.json`). This is a **second opinion** from a model in a different vendor lineage. It is **advisory only**: surface findings, do not apply changes.
+
+## Run the review
+
+!`bash ${CLAUDE_SKILL_DIR}/scripts/review.sh "$1" 2>&1`
+
+## Present the result
+
+The script printed the findings above and saved a markdown copy under `flow/reviews/`. In your reply:
+
+1. **Surface the findings clearly** to the user, with the saved file path so they can re-read it.
+2. **Do NOT modify any code** based on what the reviewer said. The reviewer is a second opinion, not an instruction.
+3. If the user asks you to act on a specific finding, treat it as a separate task and apply your own judgement; the reviewer may be wrong.
+
+## If the script errored
+
+Common causes (the printed error points at one of these):
+- `profiles.json` missing: copy `.claude/skills/cross-review/profiles.example.json` to `profiles.json` and edit endpoints/models.
+- Authentication: `az login` (Foundry), `gh auth login` (GitHub Models), `copilot auth login` (Copilot CLI).
+- Tool not installed: `az`, `gh`, `copilot`, `jq`, or `curl` missing.
+- No diff vs `main`: the branch has no changes to review.
+
+Tell the user the specific error from the script output and the fix; full setup is in [`docs/cross-vendor-review.md`](docs/cross-vendor-review.md).

--- a/.claude/skills/cross-review/profiles.example.json
+++ b/.claude/skills/cross-review/profiles.example.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Cross-vendor review profiles. Copy this file to profiles.json (gitignored) and edit endpoints and models. All backends use OAuth; no static API keys go here. Ensure 'az login' (Foundry), 'gh auth login' (GitHub Models), or 'copilot auth login' (Copilot CLI) is done for whichever backends you use.",
+  "default": "foundry-gpt4o",
+  "profiles": {
+    "foundry-gpt4o": {
+      "_comment": "Azure AI Foundry next-gen, OpenAI-compatible v1 endpoint. Recommended. No api-version needed (the /openai/v1/ path IS the version). Entra token scope: https://ai.azure.com/.default.",
+      "backend": "azure-foundry-openai",
+      "endpoint": "https://YOUR-RESOURCE.openai.azure.com",
+      "deployment": "gpt-4o"
+    },
+    "foundry-o3": {
+      "backend": "azure-foundry-openai",
+      "endpoint": "https://YOUR-RESOURCE.openai.azure.com",
+      "deployment": "o3"
+    },
+    "foundry-llama-inference": {
+      "_comment": "Legacy AI Inference endpoint (/models/chat/completions). DEPRECATED - retires 2026-08-26. Use azure-foundry-openai when your model is available there.",
+      "backend": "azure-foundry-inference",
+      "endpoint": "https://YOUR-PROJECT.services.ai.azure.com",
+      "model": "Meta-Llama-3.1-70B-Instruct",
+      "api_version": "2024-05-01-preview"
+    },
+    "github-o3-mini": {
+      "_comment": "GitHub Models via gh OAuth token. Pick any model from the GitHub Models catalog.",
+      "backend": "github-models",
+      "model": "openai/o3-mini"
+    },
+    "github-gpt4o": {
+      "backend": "github-models",
+      "model": "openai/gpt-4o"
+    },
+    "copilot-auto": {
+      "_comment": "GitHub Copilot CLI as the reviewer (uses your Copilot subscription). 'auto' lets Copilot pick the model; or specify e.g. 'gpt-4o'.",
+      "backend": "copilot-cli",
+      "model": "auto"
+    }
+  }
+}

--- a/.claude/skills/cross-review/scripts/review.sh
+++ b/.claude/skills/cross-review/scripts/review.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# /cross-review backend dispatcher.
+#
+# Sends a code-review prompt about the current branch's diff vs main
+# to a configurable OAuth-backed reviewer model from a different vendor.
+#
+# Usage:  review.sh [profile-name]
+# Env:    CROSS_REVIEW_BASE  base ref for the diff (default: main)
+#
+# Reads profiles.json (or profiles.example.json as fallback) from the skill dir.
+# Backends: azure-foundry-openai, azure-foundry-inference, github-models, copilot-cli.
+# All backends use OAuth, no static API keys.
+#
+# Output: prints findings to stdout AND saves a copy at
+#         flow/reviews/<branch>-cross-review-<timestamp>.md
+
+set -euo pipefail
+
+# --- Locate skill dir + profiles
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROFILES_FILE="${SKILL_DIR}/profiles.json"
+if [ ! -f "$PROFILES_FILE" ]; then
+  if [ -f "${SKILL_DIR}/profiles.example.json" ]; then
+    PROFILES_FILE="${SKILL_DIR}/profiles.example.json"
+    echo "WARN: profiles.json not found; using profiles.example.json. Copy it to profiles.json and customise." >&2
+  else
+    echo "ERROR: no profiles file under $SKILL_DIR" >&2
+    exit 2
+  fi
+fi
+
+# --- Prerequisites that every run needs
+for cmd in jq curl git; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: '$cmd' not installed." >&2; exit 3; }
+done
+
+# --- Resolve profile
+PROFILE_ARG="${1:-}"
+DEFAULT_PROFILE="$(jq -r '.default // empty' "$PROFILES_FILE")"
+PROFILE_NAME="${PROFILE_ARG:-$DEFAULT_PROFILE}"
+if [ -z "$PROFILE_NAME" ]; then
+  echo "ERROR: no profile specified and no .default in $(basename "$PROFILES_FILE")." >&2
+  echo "Available: $(jq -r '.profiles | keys | join(", ")' "$PROFILES_FILE")" >&2
+  exit 2
+fi
+PROFILE_JSON="$(jq -c --arg name "$PROFILE_NAME" '.profiles[$name] // empty' "$PROFILES_FILE")"
+if [ -z "$PROFILE_JSON" ] || [ "$PROFILE_JSON" = "null" ]; then
+  echo "ERROR: profile '$PROFILE_NAME' not found in $(basename "$PROFILES_FILE")." >&2
+  echo "Available: $(jq -r '.profiles | keys | join(", ")' "$PROFILES_FILE")" >&2
+  exit 2
+fi
+BACKEND="$(echo "$PROFILE_JSON" | jq -r '.backend // empty')"
+if [ -z "$BACKEND" ]; then
+  echo "ERROR: profile '$PROFILE_NAME' missing .backend" >&2
+  exit 2
+fi
+
+# Helper: extract a required field from the profile or fail with a clear message.
+require_field() {
+  local key="$1"
+  local val
+  val="$(echo "$PROFILE_JSON" | jq -r --arg k "$key" '.[$k] // empty')"
+  if [ -z "$val" ]; then
+    echo "ERROR: profile '$PROFILE_NAME' missing field .$key" >&2
+    exit 2
+  fi
+  printf '%s' "$val"
+}
+
+# --- Compute diff vs base
+BASE_REF="${CROSS_REVIEW_BASE:-main}"
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "ERROR: base ref '$BASE_REF' not found (set CROSS_REVIEW_BASE to override)." >&2
+  exit 2
+fi
+DIFF="$(git diff "${BASE_REF}...HEAD")"
+if [ -z "$DIFF" ]; then
+  echo "INFO: no diff between $BASE_REF and HEAD; nothing to review." >&2
+  exit 0
+fi
+DIFF_LINES="$(printf '%s\n' "$DIFF" | wc -l)"
+if [ "$DIFF_LINES" -gt 5000 ]; then
+  echo "WARN: diff is ${DIFF_LINES} lines; may exceed reviewer context. Consider narrowing with CROSS_REVIEW_BASE=<closer-ref>." >&2
+fi
+
+# --- Build review prompt
+PROMPT_HEADER="$(cat <<'EOF'
+You are an ADVISORY code reviewer. Another model wrote the change shown below as a unified diff; you are a SECOND opinion from a different vendor.
+
+INSTRUCTIONS:
+- Report ONLY HIGH or CRITICAL findings: correctness bugs, security issues (injection, auth bypass, secret leakage, unsafe deserialisation), logic errors, race conditions, data-loss risk, regressions, broken invariants.
+- SKIP nitpicks, style, naming, doc wording, minor refactors. Existing style is intentional.
+- For each finding, give: file:line, severity (HIGH or CRITICAL), what is wrong, why it matters.
+- If there are no HIGH or CRITICAL issues, reply exactly: "No high or critical issues found."
+- Do NOT propose code rewrites; describe the issue and let the human decide how to fix.
+
+DIFF:
+EOF
+)"
+PROMPT="${PROMPT_HEADER}
+${DIFF}"
+
+# --- Backend dispatch
+RESPONSE_TEXT=""
+MODEL_LABEL=""
+
+case "$BACKEND" in
+
+  azure-foundry-openai)
+    ENDPOINT="$(require_field endpoint)"
+    DEPLOYMENT="$(require_field deployment)"
+    command -v az >/dev/null 2>&1 || { echo "ERROR: 'az' CLI not installed." >&2; exit 3; }
+    # Foundry next-gen v1: NO api-version query; the /openai/v1/ path IS the version.
+    # Entra scope for the v1 endpoint is ai.azure.com (not the legacy cognitiveservices).
+    if ! TOKEN="$(az account get-access-token --scope https://ai.azure.com/.default --query accessToken -o tsv 2>/dev/null)"; then
+      echo "ERROR: 'az account get-access-token' failed. Run 'az login' first." >&2
+      exit 3
+    fi
+    URL="${ENDPOINT%/}/openai/v1/chat/completions"
+    PAYLOAD="$(jq -n --arg p "$PROMPT" --arg m "$DEPLOYMENT" \
+      '{model:$m, messages:[{role:"user",content:$p}], temperature:0.2, max_tokens:4096}')"
+    if ! HTTP_RESPONSE="$(curl -sS -X POST "$URL" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        --data-binary "$PAYLOAD" 2>&1)"; then
+      echo "ERROR: HTTP request to $URL failed: $HTTP_RESPONSE" >&2
+      exit 4
+    fi
+    RESPONSE_TEXT="$(printf '%s' "$HTTP_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+    if [ -z "$RESPONSE_TEXT" ]; then
+      RESPONSE_TEXT="(no content from model; raw response below)
+\`\`\`
+${HTTP_RESPONSE}
+\`\`\`"
+    fi
+    MODEL_LABEL="azure-foundry-openai: deployment=${DEPLOYMENT}, endpoint=${ENDPOINT}"
+    ;;
+
+  azure-foundry-inference)
+    ENDPOINT="$(require_field endpoint)"
+    MODEL="$(require_field model)"
+    API_VERSION="$(echo "$PROFILE_JSON" | jq -r '.api_version // "2024-05-01-preview"')"
+    command -v az >/dev/null 2>&1 || { echo "ERROR: 'az' CLI not installed." >&2; exit 3; }
+    # Azure AI Inference endpoint (/models/chat/completions) is DEPRECATED; retires 2026-08-26.
+    # Legacy Entra scope: cognitiveservices.azure.com (different from v1 above).
+    if ! TOKEN="$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv 2>/dev/null)"; then
+      echo "ERROR: 'az account get-access-token' failed. Run 'az login' first." >&2
+      exit 3
+    fi
+    URL="${ENDPOINT%/}/models/chat/completions?api-version=${API_VERSION}"
+    PAYLOAD="$(jq -n --arg p "$PROMPT" --arg m "$MODEL" \
+      '{model:$m, messages:[{role:"user",content:$p}], temperature:0.2, max_tokens:4096}')"
+    if ! HTTP_RESPONSE="$(curl -sS -X POST "$URL" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        --data-binary "$PAYLOAD" 2>&1)"; then
+      echo "ERROR: HTTP request to $URL failed: $HTTP_RESPONSE" >&2
+      exit 4
+    fi
+    RESPONSE_TEXT="$(printf '%s' "$HTTP_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+    if [ -z "$RESPONSE_TEXT" ]; then
+      RESPONSE_TEXT="(no content from model; raw response below)
+\`\`\`
+${HTTP_RESPONSE}
+\`\`\`"
+    fi
+    MODEL_LABEL="azure-foundry-inference (DEPRECATED, retires 2026-08-26): model=${MODEL}, endpoint=${ENDPOINT}"
+    ;;
+
+  github-models)
+    MODEL="$(require_field model)"
+    GH_API_VERSION="$(echo "$PROFILE_JSON" | jq -r '.api_version // "2026-03-10"')"
+    command -v gh >/dev/null 2>&1 || { echo "ERROR: 'gh' CLI not installed." >&2; exit 3; }
+    if ! TOKEN="$(gh auth token 2>/dev/null)"; then
+      echo "ERROR: 'gh auth token' failed. Run 'gh auth login' first." >&2
+      exit 3
+    fi
+    URL="https://models.github.ai/inference/chat/completions"
+    PAYLOAD="$(jq -n --arg p "$PROMPT" --arg m "$MODEL" \
+      '{model:$m, messages:[{role:"user",content:$p}], temperature:0.2, max_tokens:4096}')"
+    if ! HTTP_RESPONSE="$(curl -sS -X POST "$URL" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "X-GitHub-Api-Version: ${GH_API_VERSION}" \
+        -H "Accept: application/vnd.github+json" \
+        --data-binary "$PAYLOAD" 2>&1)"; then
+      echo "ERROR: HTTP request to $URL failed: $HTTP_RESPONSE" >&2
+      exit 4
+    fi
+    RESPONSE_TEXT="$(printf '%s' "$HTTP_RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)"
+    if [ -z "$RESPONSE_TEXT" ]; then
+      RESPONSE_TEXT="(no content from model; raw response below)
+\`\`\`
+${HTTP_RESPONSE}
+\`\`\`"
+    fi
+    MODEL_LABEL="github-models: model=${MODEL}"
+    ;;
+
+  copilot-cli)
+    MODEL="$(echo "$PROFILE_JSON" | jq -r '.model // "auto"')"
+    command -v copilot >/dev/null 2>&1 || {
+      echo "ERROR: 'copilot' CLI not installed. See https://docs.github.com/copilot/concepts/agents/about-copilot-cli" >&2
+      exit 3
+    }
+    # -p: prompt; -s: silent (suppress usage stats); --allow-all-tools required for programmatic use;
+    # --deny-tool=write blocks file modifications so the review stays read-only.
+    if ! RESPONSE_TEXT="$(copilot -p "$PROMPT" -s --model="$MODEL" --allow-all-tools --deny-tool=write 2>&1)"; then
+      echo "ERROR: copilot CLI invocation failed:" >&2
+      echo "$RESPONSE_TEXT" >&2
+      exit 4
+    fi
+    MODEL_LABEL="copilot-cli: model=${MODEL}"
+    ;;
+
+  *)
+    echo "ERROR: unknown backend '$BACKEND' in profile '$PROFILE_NAME'." >&2
+    echo "Supported: azure-foundry-openai, azure-foundry-inference, github-models, copilot-cli." >&2
+    exit 2
+    ;;
+esac
+
+# --- Save and print
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BRANCH="$(git branch --show-current | tr '/' '-')"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTPUT_DIR="${REPO_ROOT}/flow/reviews"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_FILE="${OUTPUT_DIR}/${BRANCH}-cross-review-${TIMESTAMP}.md"
+
+cat > "$OUTPUT_FILE" <<EOF
+---
+profile: ${PROFILE_NAME}
+backend: ${BACKEND}
+model: ${MODEL_LABEL}
+base_ref: ${BASE_REF}
+branch: $(git branch --show-current)
+timestamp: ${TIMESTAMP}
+---
+
+# Cross-vendor review
+
+**Advisory only.** A second-opinion review from a different-lineage model. Apply human judgement; the reviewer may be wrong.
+
+## Findings
+
+${RESPONSE_TEXT}
+EOF
+
+echo "=== Cross-vendor review (profile=${PROFILE_NAME}, backend=${BACKEND}) ==="
+echo ""
+echo "${RESPONSE_TEXT}"
+echo ""
+echo "Saved: ${OUTPUT_FILE}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # Claude Code local settings (user-specific)
 .claude/settings.local.json
 
+# Cross-vendor review user profiles (endpoint URLs may identify private Azure resources)
+.claude/skills/cross-review/profiles.json
+
 # Ralph runtime state
 .ralph/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Each workflow stage in [AGENTS.md](AGENTS.md) is an explicit-invocation skill in
 | Plan | [`/create-plan <issue URL>`](.claude/skills/create-plan/SKILL.md) | `flow/plans/` |
 | Implement | [`/implement-plan <plan path>`](.claude/skills/implement-plan/SKILL.md) | code, tests |
 | Validate | [`/validate-plan <plan path>`](.claude/skills/validate-plan/SKILL.md) | quality gate |
+| Cross-vendor review (optional) | [`/cross-review [profile]`](.claude/skills/cross-review/SKILL.md) | `flow/reviews/` |
 | PR description | [`/describe-pr`](.claude/skills/describe-pr/SKILL.md) | `flow/prs/` |
 | PR feedback | [`/handle-pr-feedback`](.claude/skills/handle-pr-feedback/SKILL.md) | code, plan updates |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses the **Claude Code Flow** template - a structured workflow for 
 
 **Manual (step-by-step):**
 
-[/research-requirements](.claude/skills/research-requirements/SKILL.md) → [/create-plan](.claude/skills/create-plan/SKILL.md) → [/implement-plan](.claude/skills/implement-plan/SKILL.md) → [/validate-plan](.claude/skills/validate-plan/SKILL.md) → [/commit](.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](.claude/skills/handle-pr-feedback/SKILL.md) (if needed) → Merge
+[/research-requirements](.claude/skills/research-requirements/SKILL.md) → [/create-plan](.claude/skills/create-plan/SKILL.md) → [/implement-plan](.claude/skills/implement-plan/SKILL.md) → [/validate-plan](.claude/skills/validate-plan/SKILL.md) → [/cross-review](.claude/skills/cross-review/SKILL.md) (optional, advisory) → [/commit](.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](.claude/skills/handle-pr-feedback/SKILL.md) (if needed) → Merge
 
 **Autonomous (unattended):**
 ```bash

--- a/docs/cross-vendor-review.md
+++ b/docs/cross-vendor-review.md
@@ -1,0 +1,69 @@
+# Cross-vendor review (optional, advisory)
+
+Run a code review on the current branch's diff vs `main` using a model from a **different vendor lineage** than the author. Optional, opt-in, advisory only: it never blocks merge and never edits code.
+
+## Why
+
+Same-vendor reviewers share blind spots ([correlated errors](https://arxiv.org/html/2506.07962v1)). A model in a different lineage catches different classes of issue. Use this on changes where a missed bug would be expensive.
+
+## When (and when not)
+
+- **Use it** on security-critical or architectural changes, before opening or updating a PR.
+- **Don't use it** on every save; it doubles to triples the per-PR model cost.
+- The severity filter is **HIGH and CRITICAL only** by design - cross-vendor LLM review surfaces real bugs better than nitpicks, and same-lineage models already cover style/quality well.
+
+## One-time setup
+
+1. **Tools.** All backends need `jq` and `curl`. Then per backend, install the CLI you intend to use:
+   - Azure Foundry: [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
+   - GitHub Models: [GitHub CLI](https://cli.github.com/)
+   - Copilot CLI: [GitHub Copilot CLI](https://docs.github.com/copilot/concepts/agents/about-copilot-cli)
+
+2. **Authenticate (OAuth, no static keys go in the repo).**
+   - `az login` - Entra ID for Foundry.
+   - `gh auth login` - GitHub token for GitHub Models.
+   - `copilot auth login` - Copilot subscription for Copilot CLI.
+
+3. **Create your profiles file.**
+   ```bash
+   cp .claude/skills/cross-review/profiles.example.json \
+      .claude/skills/cross-review/profiles.json
+   ```
+   Then edit `profiles.json` and fill in your Foundry endpoint(s) and deployment / model names. The file is gitignored.
+
+## Usage
+
+```text
+/cross-review                    # uses the default profile from profiles.json
+/cross-review github-o3-mini     # picks a specific profile by name
+```
+
+Or, to narrow the review to less than the full branch:
+```bash
+CROSS_REVIEW_BASE=HEAD~3 /cross-review foundry-gpt4o
+```
+
+The skill prints findings inline and saves a markdown copy at `flow/reviews/<branch>-cross-review-<timestamp>.md`.
+
+## Backends
+
+| Backend | OAuth token | Endpoint / call | Model selection |
+|---|---|---|---|
+| `azure-foundry-openai` | `az account get-access-token --scope https://ai.azure.com/.default` | `POST {endpoint}/openai/v1/chat/completions` (no `api-version` - the v1 path is the version) | by Foundry deployment name. **Recommended.** |
+| `azure-foundry-inference` | `az account get-access-token --scope https://cognitiveservices.azure.com/.default` | `POST {endpoint}/models/chat/completions?api-version=2024-05-01-preview` | by model id. **Deprecated, retires 2026-08-26** - migrate to `azure-foundry-openai`. |
+| `github-models` | `gh auth token` | `POST https://models.github.ai/inference/chat/completions` with `X-GitHub-Api-Version: 2026-03-10` and `Accept: application/vnd.github+json` | from the [GitHub Models catalog](https://github.com/marketplace?type=models), e.g. `openai/gpt-4o`, `openai/o3-mini`, `meta/Meta-Llama-3.1-70B-Instruct`. Works for Copilot Enterprise users with a standard `gh` token. |
+| `copilot-cli` | OAuth via `copilot auth login` (uses your Copilot subscription) | shells out: `copilot -p "<prompt>" -s --model=<m> --allow-all-tools --deny-tool=write` | `auto` or any Copilot-supported model. No key management. |
+
+`profiles.example.json` ships with sample entries for each.
+
+## Intentional limits
+
+- **Advisory only.** The skill never edits code; it surfaces findings for human triage.
+- **Explicit invocation only.** The skill sets `disable-model-invocation: true` so Claude Code does not fire it autonomously, and the script is never to be wired to a Stop hook ([codex-plugin-cc #306](https://github.com/openai/codex-plugin-cc/issues/306) is the precedent of why).
+- **No static keys in the repo.** All four backends authenticate via OAuth tokens from CLIs you already have logged in (`az`, `gh`, `copilot`).
+- **Diff scope.** Reviews the merge-base diff `main...HEAD` by default. For very large branches, set `CROSS_REVIEW_BASE=<closer-ref>` to narrow.
+
+## Alternatives considered (and not adopted)
+
+- **PAL MCP** (formerly `zen-mcp-server`): a good MCP-server review tool, but its config holds a static API key and cannot refresh Entra ID tokens, so it does not fit our keyless / OAuth-only constraint.
+- **`openai/codex-plugin-cc`**: usable via an explicit `/codex:adversarial-review`, but heavier (npm + plugin + `codex login`) and carries two open issues - [#306](https://github.com/openai/codex-plugin-cc/issues/306) (Stop-hook infinite loop on rate limit) and [#320](https://github.com/openai/codex-plugin-cc/issues/320) (subscription auth broken). If you specifically want Codex models reviewing, the `copilot-cli` backend reaches them via your Copilot Enterprise subscription instead.


### PR DESCRIPTION
## Summary

Add an OPTIONAL, advisory `/cross-review` skill that posts the current branch's diff vs `main` to a configurable second-opinion model from a different vendor lineage. All four supported backends authenticate via **OAuth - no static API keys live in the repo**. Implements tracker item T1.3.

## Changes

- New explicit-only skill at `.claude/skills/cross-review/SKILL.md` (`disable-model-invocation: true`), delegates to the dispatcher.
- Bash dispatcher `scripts/review.sh` with four backends:
  - **`azure-foundry-openai`** - Foundry next-gen v1 (`/openai/v1/chat/completions`, scope `https://ai.azure.com/.default`, no api-version), model = deployment name.
  - **`azure-foundry-inference`** - legacy `/models/chat/completions` (deprecated, retires 2026-08-26, scope `https://cognitiveservices.azure.com/.default`).
  - **`github-models`** - `https://models.github.ai/inference/chat/completions` with `gh auth token` and `X-GitHub-Api-Version: 2026-03-10`.
  - **`copilot-cli`** - `copilot -p ... -s --model=<m> --allow-all-tools --deny-tool=write`, using your Copilot subscription.
- Per-invocation backend/model selection via named profiles in `.claude/skills/cross-review/profiles.json` (gitignored; `profiles.example.json` is the template).
- Output saved to `flow/reviews/<branch>-cross-review-<timestamp>.md` and printed inline; severity filter HIGH/CRITICAL only.
- Docs at `docs/cross-vendor-review.md` (setup per backend, caveats, why PAL MCP and `openai/codex-plugin-cc` were not adopted).
- Reference updates: `CLAUDE.md` (workflow-skills table), `README.md` (workflow chain), `.gitignore`.

## Test Plan

- [ ] Copy `profiles.example.json` to `profiles.json`; fill in your Foundry endpoint + deployment and/or GitHub Models model id.
- [ ] Run `az login` / `gh auth login` / `copilot auth login` for whichever backends you'll use.
- [ ] Restart Claude Code to pick up the new skill, then invoke `/cross-review` (default profile) and `/cross-review <profile>` on a branch with changes vs `main`.
- [ ] Verify findings print inline and a markdown copy is saved under `flow/reviews/`.
- [ ] Confirm the skill does NOT auto-fire (a generic "review this" prompt should not auto-trigger it).
- [ ] Negative path: `/cross-review nonexistent-profile` errors cleanly with the available-profiles list.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: template repo, no test suite; `bash -n` and `jq` validated the script and profile JSON)
- [x] Documentation updated (`docs/cross-vendor-review.md`, `CLAUDE.md`, `README.md`)

## Context

- **OAuth, not API keys**: the initial design (PAL MCP + raw Gemini key) was rejected because PAL cannot hold a refreshing Entra ID token. This design pivots to direct CLI calls (`az`, `gh`, `copilot`) so each invocation mints a fresh OAuth token from the user's existing login - fitting enterprise keyless setups (Entra ID for Foundry, GitHub OAuth for Models/Copilot).
- **Configurability**: the profiles file lets you switch reviewer per invocation (Foundry deployment, GitHub Models catalog id, or Copilot's model picker).
- **Endpoint specifics verified against official MS Learn and docs.github.com (2026-05-22)**: Foundry v1 uses the `/openai/v1/` path with `ai.azure.com` scope (not the legacy `cognitiveservices.azure.com`); GitHub Models requires `X-GitHub-Api-Version: 2026-03-10`; Copilot CLI's `--allow-all-tools --deny-tool=write` is the documented safe pattern for headless review.
- **Ralph review untouched**: swapping the existing `@claude` PR review for a vendor-neutral one is the larger L2 (CLI-agnostic) item, deliberately out of scope here.
- Follows T1.1 (#31) and T2.2 (#32).
