### PR TITLE
Gitignore flow/tests/ for local manual test plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ logs/
 # Local research / implementation tracker (working doc, intentionally not committed)
 flow/research/2026-05-21-agentic-coding-state-of-the-art.md
 
+# Local manual test plans (working notes; not committed)
+flow/tests/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

Add `flow/tests/` to `.gitignore` so per-feature manual test playbooks (and other local working notes) can live in a known on-disk location without being committed.

## Changes

- `.gitignore`: new 3-line section ignoring `flow/tests/`.

## Rationale

Mirrors the existing `flow/research/2026-05-21-...md` ignore pattern. Provides a stable home for local manual test scripts (e.g. a checklist for verifying skills in both Claude Code and Copilot CLI, plus the cross-vendor review skill) without coupling those notes to the repo's git history.

## Test Plan

- [x] `git check-ignore flow/tests/<file>.md` confirms the path is ignored after the change.
- [x] `git status` shows only `.gitignore` modified; local test plans do not appear.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: gitignore-only change)
- [x] Documentation updated (N/A: internal infra)
