### PR TITLE
Abstract issue tracker via .claude/scripts/tracker.sh; refactor 9 skills (PR 1)

### DIFF
--- a/.claude/scripts/tracker.sh
+++ b/.claude/scripts/tracker.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Tracker adapter: abstracts issue / work-item and PR operations across trackers.
+#
+# Workflow skills call this script instead of using a specific tracker's CLI
+# directly. Today the only fully wired backend is `github` (which dispatches
+# to `gh`). The `azure-devops` backend is a stub returning a clear error;
+# the `none` backend is a tracker-less mode for projects without an issue tracker.
+#
+# Usage:  bash .claude/scripts/tracker.sh <subcommand> <args...>
+#
+# Subcommands (issue / work-item):
+#   view <id> [--json field1,field2,...]      Fetch a work item as JSON.
+#   set-state <id> <new> [<old>]              Apply a state transition.
+#   comment <id> <text>                       Post a comment on a work item.
+#
+# Subcommands (PR / merge request):
+#   pr-current [--json fields]                Fetch the PR for the current branch.
+#   pr-view <id> [--json fields]              Fetch a PR by id.
+#   pr-diff <id>                              Print the PR diff.
+#   pr-edit-body <id> <body-file>             Replace the PR description.
+#   pr-comment <id> <text>                    Post a comment on the PR.
+#   pr-list-open                              List recent open PRs.
+#   pr-reviews <id>                           Fetch reviews on a PR.
+#   pr-review-comments <id>                   Fetch inline review comments.
+#   pr-decision <id>                          Fetch the PR review decision.
+#   pr-closing-issues <id>                    List issues this PR will close.
+#
+# Subcommands (utility):
+#   repo-info                                 Owner + repo name as JSON.
+#   backend                                   Print the active backend name.
+#
+# Backend selection: reads `.claude/tracker.json` (gitignored) if present,
+# else `.claude/tracker.example.json`, else defaults to `github`. Override
+# at runtime with `TRACKER_BACKEND=<name>`.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CONFIG="${REPO_ROOT}/.claude/tracker.json"
+[ ! -f "$CONFIG" ] && CONFIG="${REPO_ROOT}/.claude/tracker.example.json"
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: 'jq' not installed" >&2; exit 3; }
+
+if [ -n "${TRACKER_BACKEND:-}" ]; then
+  BACKEND="$TRACKER_BACKEND"
+elif [ -f "$CONFIG" ]; then
+  BACKEND="$(jq -r '.tracker // "github"' "$CONFIG")"
+else
+  BACKEND="github"
+fi
+
+abort() { echo "ERROR: $1" >&2; exit "${2:-2}"; }
+
+# Extract a `--json fields` pair from a remaining-args list, leaving other args alone.
+# Sets globals: _JSON_FIELDS (string) and _REST (array).
+parse_json_arg() {
+  _JSON_FIELDS=""
+  _REST=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json)
+        shift
+        _JSON_FIELDS="${1:-}"
+        shift || true
+        ;;
+      *)
+        _REST+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+# ----------------------------------------------------------------------------
+# GitHub backend
+# ----------------------------------------------------------------------------
+gh_require() { command -v gh >/dev/null 2>&1 || abort "'gh' CLI not installed; run 'gh auth login'" 3; }
+
+gh_view() {
+  gh_require
+  local id="$1"; shift
+  parse_json_arg "$@"
+  local fields="${_JSON_FIELDS:-title,body,state,labels,comments}"
+  gh issue view "$id" --json "$fields"
+}
+
+gh_set_state() {
+  gh_require
+  local id="$1" new="$2" old="${3:-}"
+  if [ -n "$old" ]; then
+    gh issue edit "$id" --add-label "$new" --remove-label "$old"
+  else
+    gh issue edit "$id" --add-label "$new"
+  fi
+}
+
+gh_comment() {
+  gh_require
+  gh issue comment "$1" --body "$2"
+}
+
+gh_pr_current() {
+  gh_require
+  parse_json_arg "$@"
+  local fields="${_JSON_FIELDS:-number,title,headRefName,state,url}"
+  gh pr view --json "$fields"
+}
+
+gh_pr_view() {
+  gh_require
+  local id="$1"; shift
+  parse_json_arg "$@"
+  local fields="${_JSON_FIELDS:-title,body,state,reviews,comments,baseRefName,headRefName,url}"
+  gh pr view "$id" --json "$fields"
+}
+
+gh_pr_diff()         { gh_require; gh pr diff "$1"; }
+gh_pr_edit_body()    { gh_require; gh pr edit "$1" --body-file "$2"; }
+gh_pr_comment()      { gh_require; gh pr comment "$1" --body "$2"; }
+gh_pr_list_open()    { gh_require; gh pr list --limit 10 --json number,title,headRefName,author; }
+gh_pr_reviews()      { gh_require; gh pr view "$1" --json reviews; }
+gh_pr_review_comments() { gh_require; gh api "repos/:owner/:repo/pulls/$1/comments"; }
+gh_pr_decision()     { gh_require; gh pr view "$1" --json reviewDecision; }
+gh_pr_closing_issues() { gh_require; gh pr view "$1" --json closingIssuesReferences --jq '.closingIssuesReferences[].number'; }
+gh_repo_info()       { gh_require; gh repo view --json owner,name; }
+
+# ----------------------------------------------------------------------------
+# Azure DevOps backend (stub - implemented in PR 2)
+# ----------------------------------------------------------------------------
+azdo_stub() {
+  abort "azure-devops backend is not implemented yet (PR 2). See docs/tracker-portability.md." 3
+}
+
+# ----------------------------------------------------------------------------
+# None backend (tracker-less projects)
+# ----------------------------------------------------------------------------
+# Query subcommands return empty JSON so callers proceed gracefully.
+# Mutating subcommands log and exit 0 so the workflow flows on.
+none_query()    { echo "{}"; }
+none_mutating() { echo "INFO: tracker=none; skipping $1" >&2; }
+
+# ----------------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------------
+SUBCMD="${1:-}"
+[ -z "$SUBCMD" ] && abort "missing subcommand (try: backend, view, set-state, pr-view, ...)" 2
+shift
+
+case "$BACKEND" in
+  github)
+    case "$SUBCMD" in
+      backend) echo github ;;
+      view) gh_view "$@" ;;
+      set-state) gh_set_state "$@" ;;
+      comment) gh_comment "$@" ;;
+      pr-current) gh_pr_current "$@" ;;
+      pr-view) gh_pr_view "$@" ;;
+      pr-diff) gh_pr_diff "$@" ;;
+      pr-edit-body) gh_pr_edit_body "$@" ;;
+      pr-comment) gh_pr_comment "$@" ;;
+      pr-list-open) gh_pr_list_open ;;
+      pr-reviews) gh_pr_reviews "$@" ;;
+      pr-review-comments) gh_pr_review_comments "$@" ;;
+      pr-decision) gh_pr_decision "$@" ;;
+      pr-closing-issues) gh_pr_closing_issues "$@" ;;
+      repo-info) gh_repo_info ;;
+      *) abort "unknown subcommand for github backend: $SUBCMD" 2 ;;
+    esac
+    ;;
+
+  azure-devops)
+    case "$SUBCMD" in
+      backend) echo azure-devops ;;
+      *) azdo_stub ;;
+    esac
+    ;;
+
+  none)
+    case "$SUBCMD" in
+      backend) echo none ;;
+      view|pr-current|pr-view|pr-diff|pr-list-open|pr-reviews|pr-review-comments|pr-decision|pr-closing-issues|repo-info)
+        none_query ;;
+      set-state|comment|pr-edit-body|pr-comment)
+        none_mutating "$SUBCMD" ;;
+      *) abort "unknown subcommand for none backend: $SUBCMD" 2 ;;
+    esac
+    ;;
+
+  *)
+    abort "unknown tracker backend: $BACKEND (supported: github, azure-devops, none)" 2
+    ;;
+esac

--- a/.claude/skills/create-handoff/SKILL.md
+++ b/.claude/skills/create-handoff/SKILL.md
@@ -12,8 +12,8 @@ You are tasked with writing a handoff document to hand off your work to another 
 ## Process
 ### 1. Filepath & Metadata
 Use the following information to understand how to create your document:
-    - Create your file under `flow/handoffs/gh-<number>/YYYY-MM-DD_HH-MM-SS_description.md`, where:
-        - `gh-<number>` is the GitHub issue number (use `general` if no issue)
+    - Create your file under `flow/handoffs/gh-<id>/YYYY-MM-DD_HH-MM-SS_description.md`, where:
+        - `gh-<id>` uses the tracker work-item id (use `general` if no tracker reference). The literal `gh-` prefix is a stable filename convention across the repo regardless of which tracker the project uses.
         - YYYY-MM-DD is today's date
         - HH-MM-SS is the hours, minutes and seconds based on the current time, in 24-hour format
         - description is a brief kebab-case description
@@ -22,8 +22,8 @@ Use the following information to understand how to create your document:
         - `git branch --show-current` for branch name
         - `git remote get-url origin` for repository
     - Examples:
-        - With issue: `flow/handoffs/gh-123/2025-01-08_13-55-22_implement-streaming-api.md`
-        - Without issue: `flow/handoffs/general/2025-01-08_13-55-22_refactor-config.md`
+        - With a tracker work item: `flow/handoffs/gh-123/2025-01-08_13-55-22_implement-streaming-api.md`
+        - Without a tracker reference: `flow/handoffs/general/2025-01-08_13-55-22_refactor-config.md`
 
 ### 2. Handoff writing
 Using the above conventions, write your document. Use the defined filepath and the following YAML frontmatter pattern:

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-plan
-description: Research the codebase and author a phased implementation plan under flow/plans/ from a GitHub issue or task. Explicit workflow command; run only when invoked via /create-plan or explicitly asked, never autonomously.
-argument-hint: [github-issue-url-or-number]
+description: Research the codebase and author a phased implementation plan under flow/plans/ from an issue / work item or task. Explicit workflow command; run only when invoked via /create-plan or explicitly asked, never autonomously.
+argument-hint: [issue-url-or-id]
 model: opus
 disable-model-invocation: true
 ---
@@ -139,13 +139,13 @@ When this command is invoked:
 I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
 
 Please provide:
-1. A GitHub issue URL or number (e.g., #123)
+1. An issue / work-item URL or id (e.g., #123 on GitHub, or an Azure DevOps work item URL)
 2. Or a task description with relevant context and constraints
 3. Links to related research or previous implementations
 
 I'll analyze this information and work with you to create a comprehensive plan.
 
-Tip: You can invoke this command with a GitHub issue: `/create-plan #123` or `/create-plan https://github.com/owner/repo/issues/123`
+Tip: You can invoke this with an issue / work-item reference: `/create-plan #123`, a full URL like `/create-plan https://github.com/owner/repo/issues/123` (GitHub), or `/create-plan https://dev.azure.com/org/project/_workitems/edit/123` (Azure DevOps)
 For deeper analysis, try: `/create-plan think deeply about #123`
 ```
 
@@ -155,12 +155,12 @@ Then wait for the user's input.
 
 ### Step 1: Context Gathering & Initial Analysis
 
-1. **Fetch GitHub issue if provided**:
-   - If a GitHub issue URL or number is provided:
-     - Fetch it: `gh issue view <number> --json title,body,labels,comments`
-     - Update label: `gh issue edit <number> --add-label "planning-in-progress" --remove-label "research-complete"`
-   - Read the issue content fully before proceeding
-   - Note any linked issues, PRs, or references mentioned
+1. **Fetch the work item if provided**:
+   - If a tracker URL or work-item id is provided:
+     - Fetch it: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
+     - Transition state: `bash .claude/scripts/tracker.sh set-state <id> planning-in-progress research-complete`
+   - Read the content fully before proceeding
+   - Note any linked work items, PRs, or references mentioned
 
 2. **Read all mentioned files immediately and FULLY**:
    - Research documents (e.g., `flow/research/...`)
@@ -291,7 +291,7 @@ After structure approval:
 1. **Write the plan** to `flow/plans/YYYY-MM-DD-gh-[issue]-[description].md`
    - Format: `YYYY-MM-DD-gh-[issue]-[description].md` where:
      - YYYY-MM-DD is today's date
-     - gh-[issue] is the GitHub issue number (omit if no issue)
+     - gh-[issue] is the tracker work-item id (omit if no work item; the literal "gh-" prefix is a stable filename convention across the repo regardless of tracker)
      - description is a brief kebab-case description
    - Examples:
      - With issue: `flow/plans/2026-01-12-gh-1-research-requirements-command.md`
@@ -412,7 +412,7 @@ After structure approval:
 
 ## References
 
-- GitHub issue: https://github.com/[owner]/[repo]/issues/[number]
+- Tracker work item: https://github.com/[owner]/[repo]/issues/[number] (GitHub example - substitute the URL shape for your tracker)
 - Related research: `flow/research/[relevant].md`
 - Similar implementation: `[file:line]`
 ````
@@ -439,8 +439,8 @@ After structure approval:
 
 3. **Continue refining** until the user is satisfied
 
-4. **Update GitHub issue label** (if applicable):
-   - Once the plan is finalized and approved: `gh issue edit <number> --add-label "ready-for-dev" --remove-label "planning-in-progress"`
+4. **Transition the work-item state** (if applicable):
+   - Once the plan is finalized and approved: `bash .claude/scripts/tracker.sh set-state <id> ready-for-dev planning-in-progress`
 
 ## Important Guidelines
 
@@ -584,11 +584,11 @@ tasks = [
 
 ```
 User: /create-plan #1
-Assistant: Let me fetch that GitHub issue and understand what we're building...
+Assistant: Let me fetch that work item and understand what we're building...
 
-[Fetches issue with gh issue view 1]
+[Fetches with `bash .claude/scripts/tracker.sh view 1`]
 
-Based on the issue, I understand we need to create a /research-requirements command for greenfield projects. Let me research the codebase to understand the existing patterns...
+Based on the work item, I understand we need to create a /research-requirements skill for greenfield projects. Let me research the codebase to understand the existing patterns...
 
 [Spawns research agents]
 

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -16,8 +16,8 @@ You are tasked with generating a comprehensive pull request description followin
    - Read the template carefully to understand all sections and requirements
 
 2. **Identify the PR to describe:**
-   - Check if the current branch has an associated PR: `gh pr view --json url,number,title,state 2>/dev/null`
-   - If no PR exists for the current branch, or if on main/master, list open PRs: `gh pr list --limit 10 --json number,title,headRefName,author`
+   - Check if the current branch has an associated PR: `bash .claude/scripts/tracker.sh pr-current --json url,number,title,state 2>/dev/null`
+   - If no PR exists for the current branch, or if on main/master, list open PRs: `bash .claude/scripts/tracker.sh pr-list-open`
    - Ask the user which PR they want to describe
 
 3. **Check for existing description:**
@@ -26,11 +26,11 @@ You are tasked with generating a comprehensive pull request description followin
    - Consider what has changed since the last description was written
 
 4. **Gather comprehensive PR information:**
-   - Get the full PR diff: `gh pr diff {number}`
-   - If you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
-   - Get commit history: `gh pr view {number} --json commits`
-   - Review the base branch: `gh pr view {number} --json baseRefName`
-   - Get PR metadata: `gh pr view {number} --json url,title,number,state`
+   - Get the full PR diff: `bash .claude/scripts/tracker.sh pr-diff {number}`
+   - On GitHub: if you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
+   - Get commit history: `bash .claude/scripts/tracker.sh pr-view {number} --json commits`
+   - Review the base branch: `bash .claude/scripts/tracker.sh pr-view {number} --json baseRefName`
+   - Get PR metadata: `bash .claude/scripts/tracker.sh pr-view {number} --json url,title,number,state`
 
 5. **Analyze the changes thoroughly:** (ultrathink about the code changes, their architectural implications, and potential impacts)
    - Read through the entire diff carefully
@@ -61,13 +61,13 @@ You are tasked with generating a comprehensive pull request description followin
    - Show the user the generated description
 
 9. **Update the PR:**
-   - Update the PR description directly: `gh pr edit {number} --body-file flow/prs/{number}_description.md`
+   - Update the PR description directly: `bash .claude/scripts/tracker.sh pr-edit-body {number} flow/prs/{number}_description.md`
    - Confirm the update was successful
    - If any verification steps remain unchecked, remind the user to complete them before merging
 
-10. **Update GitHub issue label** (if PR is linked to an issue):
-    - Get linked issue numbers: `gh pr view {number} --json closingIssuesReferences --jq '.closingIssuesReferences[].number'`
-    - For each linked issue: `gh issue edit <issue-number> --add-label "pr-submitted" --remove-label "in-progress"`
+10. **Transition linked work-item states** (if PR is linked to issues / work items):
+    - Get linked work-item ids: `bash .claude/scripts/tracker.sh pr-closing-issues {number}`
+    - For each linked work item: `bash .claude/scripts/tracker.sh set-state <id> pr-submitted in-progress`
 
 ## Important notes:
 - This command works across different repositories - always read the local template

--- a/.claude/skills/handle-pr-feedback/SKILL.md
+++ b/.claude/skills/handle-pr-feedback/SKILL.md
@@ -25,17 +25,18 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 - Use the provided PR number
 
 **If no PR number provided:**
-- Auto-detect from current branch: `gh pr view --json number,title,headRefName 2>/dev/null`
+- Auto-detect from current branch: `bash .claude/scripts/tracker.sh pr-current --json number,title,headRefName 2>/dev/null`
 - If multiple PRs or unclear, ask user which PR to handle
 
 ### 2. Fetch PR Review Feedback
 
 ```bash
-# Get PR review comments
-gh pr view <pr-number> --json reviews,comments --jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
+# Get PR reviews + comments. The author.login filter for "claude-code[bot]" / "@claude"
+# is GitHub-Actions-specific; substitute for other trackers / review systems.
+bash .claude/scripts/tracker.sh pr-view <pr-id> --json reviews,comments | jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
 
 # Also get inline review comments
-gh api repos/:owner/:repo/pulls/<pr-number>/comments
+bash .claude/scripts/tracker.sh pr-review-comments <pr-id>
 ```
 
 **Parse the feedback:**
@@ -45,7 +46,7 @@ gh api repos/:owner/:repo/pulls/<pr-number>/comments
 - Extract specific file locations and suggested fixes
 
 **If no feedback found:**
-- Check if review is still pending: `gh pr view <pr-number> --json reviewDecision`
+- Check if review is still pending: `bash .claude/scripts/tracker.sh pr-decision <pr-id>`
 - If APPROVED: notify user "PR already approved, no changes needed"
 - If CHANGES_REQUESTED but no comments: ask user to specify what to fix
 - If pending: notify user to wait for review to complete
@@ -55,16 +56,16 @@ gh api repos/:owner/:repo/pulls/<pr-number>/comments
 ```bash
 # Look for plan file related to this PR
 # Strategy 1: Check PR description for plan reference
-gh pr view <pr-number> --json body | grep -o "flow/plans/[^)]*"
+bash .claude/scripts/tracker.sh pr-view <pr-id> --json body | grep -o "flow/plans/[^)]*"
 
-# Strategy 2: Get issue number from PR title/body
-gh pr view <pr-number> --json title,body | grep -o "#[0-9]*" | head -1
+# Strategy 2: Get work-item id from PR title/body
+bash .claude/scripts/tracker.sh pr-view <pr-id> --json title,body | grep -o "#[0-9]*" | head -1
 
-# Then find plan:
-ls flow/plans/*-gh-<issue-number>-*.md 2>/dev/null
+# Then find plan (gh-<n> filename prefix is a stable convention regardless of tracker):
+ls flow/plans/*-gh-<work-item-id>-*.md 2>/dev/null
 
 # Strategy 3: Check commits for plan references
-gh pr view <pr-number> --json commits | grep -o "flow/plans/[^)]*"
+bash .claude/scripts/tracker.sh pr-view <pr-id> --json commits | grep -o "flow/plans/[^)]*"
 ```
 
 **If plan not found:**
@@ -188,8 +189,9 @@ git push
 ### 10. Request Re-review
 
 ```bash
-# Comment on the PR to request re-review
-gh pr comment <pr-number> --body "@claude I've addressed your feedback in the latest commit. Please re-review:
+# Comment on the PR to request re-review (the '@claude' tag triggers the
+# Claude Code GitHub Action; substitute the equivalent for other systems).
+bash .claude/scripts/tracker.sh pr-comment <pr-id> "@claude I've addressed your feedback in the latest commit. Please re-review:
 
 Changes made:
 - <change 1>
@@ -198,13 +200,13 @@ Changes made:
 All tests passing ✅"
 ```
 
-### 11. Update Plan Labels (if GitHub issue exists)
+### 11. Update Work-Item State (if PR is linked to a work item)
 
 ```bash
-# Get linked issue number
-gh pr view <pr-number> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
+# Get linked work-item ids
+bash .claude/scripts/tracker.sh pr-closing-issues <pr-id>
 
-# Keep issue in 'in-progress' (already there, no change needed)
+# Keep work item in 'in-progress' (already there, no change needed)
 ```
 
 ### 12. Report Summary

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -15,7 +15,7 @@ When given a plan path:
 - Read the plan completely and check for any existing checkmarks (- [x])
 - Read the original ticket and all files mentioned in the plan
 - **Read files fully** - never use limit/offset parameters, you need complete context
-- **Update GitHub issue label** (if issue is referenced in plan): `gh issue edit <number> --add-label "in-progress" --remove-label "ready-for-dev"`
+- **Transition the work-item state** (if an issue / work item is referenced in the plan): `bash .claude/scripts/tracker.sh set-state <id> in-progress ready-for-dev`
 - Think deeply about how the pieces fit together
 - Create a todo list to track your progress
 - Start implementing if you understand what needs to be done

--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-codebase
 description: Document the codebase as-is via parallel read-only sub-agents and write findings under flow/research/. Explicit workflow command; run only when invoked via /research-codebase or explicitly asked.
-argument-hint: [github-issue-url-or-question]
+argument-hint: [issue-url-or-question]
 model: opus
 disable-model-invocation: true
 ---
@@ -31,9 +31,9 @@ Then wait for the user's research query.
 ## Steps to follow after receiving the research query:
 
 1. **Read any directly mentioned files first:**
-   - If the research query is a GitHub issue URL or number:
-     - Fetch issue content with `gh issue view <number> --json title,body,labels,comments`
-     - Update issue label: `gh issue edit <number> --add-label "research-in-progress"`
+   - If the research query is a tracker URL or work-item id:
+     - Fetch work-item content: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
+     - Transition state: `bash .claude/scripts/tracker.sh set-state <id> research-in-progress`
    - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
    - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
    - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
@@ -92,7 +92,7 @@ Then wait for the user's research query.
    - Filename: `flow/research/YYYY-MM-DD-gh-<number>-description.md`
      - Format: `YYYY-MM-DD-gh-<number>-description.md` where:
        - YYYY-MM-DD is today's date
-       - gh-<number> is the GitHub issue number (omit if no issue)
+       - gh-<number> is the tracker work-item id (omit if no work item; the literal "gh-" prefix is a stable filename convention)
        - description is a brief kebab-case description of the research topic
      - Examples:
        - With issue: `flow/research/2025-01-08-gh-42-parent-child-tracking.md`
@@ -158,15 +158,14 @@ Then wait for the user's research query.
      [Any areas that need further investigation]
      ```
 
-7. **Add GitHub permalinks (if applicable):**
+7. **Add repository permalinks (if applicable; GitHub URL shape shown - substitute for other hosts):**
    - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
-   - If on main/master or pushed, generate GitHub permalinks:
-     - Get repo info: `gh repo view --json owner,name`
-     - Create permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - For GitHub, get repo info: `bash .claude/scripts/tracker.sh repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - For other hosts, substitute the appropriate URL shape (e.g. Azure DevOps: `https://dev.azure.com/{org}/{project}/_git/{repo}?path=/{file}&version=GC{commit}&line={line}`)
    - Replace local file references with permalinks in the document
 
 8. **Present findings:**
-   - Update GitHub issue label (if applicable): `gh issue edit <number> --add-label "research-complete" --remove-label "research-in-progress"`
+   - Transition the work-item state (if applicable): `bash .claude/scripts/tracker.sh set-state <id> research-complete research-in-progress`
    - Present a concise summary of findings to the user
    - Include key file references for easy navigation
    - Ask if they have follow-up questions or need clarification
@@ -188,7 +187,7 @@ Then wait for the user's research query.
 - Each sub-agent prompt should be specific and focused on read-only documentation operations
 - Document cross-component connections and how systems interact
 - Include temporal context (when the research was conducted)
-- Link to GitHub when possible for permanent references
+- Link to the repository host when possible for permanent references
 - Keep the main agent focused on synthesis, not deep file reading
 - Have sub-agents document examples and usage patterns as they exist
 - Explore all of flow/ directory, not just research subdirectory

--- a/.claude/skills/research-requirements/SKILL.md
+++ b/.claude/skills/research-requirements/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-requirements
 description: Research requirements, technology choices, and constraints for a feature or project and write findings under flow/research/. Explicit workflow command; run only when invoked via /research-requirements or explicitly asked.
-argument-hint: [github-issue-url-or-description]
+argument-hint: [issue-url-or-description]
 model: opus
 disable-model-invocation: true
 ---
@@ -21,14 +21,14 @@ This command researches and documents:
 When this command is invoked:
 
 1. **Check if parameters were provided**:
-   - If a GitHub issue URL or project description was provided, proceed immediately
+   - If a tracker URL or project description was provided, proceed immediately
    - Read/fetch input FULLY before spawning sub-tasks
 
 2. **If no parameters provided**, respond with:
 ```
 I'm ready to research requirements for a new project or feature. Please provide:
 - A project description, OR
-- A GitHub issue URL with requirements
+- An issue / work-item URL with requirements (any supported tracker)
 
 I'll research technology options, constraints, and existing solutions to inform planning.
 ```
@@ -39,9 +39,9 @@ Then wait for user input.
 
 ### Step 1: Parse Input Source
 
-- If GitHub URL:
-  - Fetch issue content with `gh issue view <number> --json title,body,labels,comments`
-  - Update issue label: `gh issue edit <number> --add-label "research-in-progress"`
+- If a tracker URL or work-item id was provided:
+  - Fetch the work-item content: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
+  - Transition state: `bash .claude/scripts/tracker.sh set-state <id> research-in-progress`
 - If plain text: use as-is
 - **CRITICAL**: Read/fetch input FULLY before spawning sub-tasks
 
@@ -97,7 +97,7 @@ Collect metadata for the output document:
 - Get git commit hash: `git rev-parse HEAD`
 - Get current branch: `git branch --show-current`
 - Get repository name: `basename $(git rev-parse --show-toplevel)`
-- Extract GitHub issue number (if applicable)
+- Extract tracker work-item id (if applicable)
 
 Generate filename using this convention:
 ```
@@ -105,7 +105,7 @@ flow/research/YYYY-MM-DD-gh-[issue-number]-[description].md
 ```
 
 - `YYYY-MM-DD` - today's date
-- `gh-[issue-number]` - GitHub issue number (omit if no issue)
+- `gh-[issue-number]` - tracker work-item id (omit if no work item; the literal "gh-" prefix is a stable filename convention)
 - `[description]` - brief kebab-case description
 
 Examples:
@@ -132,7 +132,7 @@ status: complete
 # Requirements Research: [Project/Feature Name]
 
 ## Original Request
-[User's input or GitHub issue content]
+[User's input or tracker work-item content]
 
 ## Summary
 [High-level findings and recommendations - 2-3 paragraphs]
@@ -182,8 +182,8 @@ status: complete
 
 After writing the document:
 
-1. **Update GitHub issue label** (if applicable):
-   - Replace label: `gh issue edit <number> --add-label "research-complete" --remove-label "research-in-progress"`
+1. **Transition the work-item state** (if applicable):
+   - `bash .claude/scripts/tracker.sh set-state <id> research-complete research-in-progress`
 
 2. **Present summary to user**:
 ```

--- a/.claude/skills/resume-handoff/SKILL.md
+++ b/.claude/skills/resume-handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resume-handoff
 description: Resume work from a handoff document, validating current state against it before continuing. Explicit-only; run only when invoked via /resume-handoff or explicitly asked.
-argument-hint: [handoff-file-or-issue-number]
+argument-hint: [handoff-file-or-work-item-id]
 disable-model-invocation: true
 ---
 
@@ -20,8 +20,8 @@ When this command is invoked:
    - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
    - Then propose a course of action to the user and confirm, or ask for clarification on direction.
 
-2. **If a GitHub issue number (like gh-123 or just 123) was provided**:
-   - Locate the most recent handoff document for the issue at `flow/handoffs/gh-<number>/`
+2. **If a tracker work-item id (like gh-123 or just 123) was provided**:
+   - Locate the most recent handoff document for the work item at `flow/handoffs/gh-<id>/`
    - **List this directory's contents.**
    - There may be zero, one or multiple files in the directory.
    - **If there are zero files in the directory, or the directory does not exist**: tell the user: "I can't find a handoff document for that issue. Can you provide a path to it?"
@@ -40,7 +40,7 @@ Which handoff would you like to resume from?
 
 Tip: You can invoke this command directly with:
 - A handoff path: `/resume-handoff flow/handoffs/gh-123/2025-01-08_description.md`
-- A GitHub issue number: `/resume-handoff 123` or `/resume-handoff gh-123`
+- A tracker work-item id: `/resume-handoff 123` or `/resume-handoff gh-123`
 ```
 
 Then wait for the user's input.

--- a/.claude/skills/validate-plan/SKILL.md
+++ b/.claude/skills/validate-plan/SKILL.md
@@ -130,17 +130,17 @@ Create comprehensive validation summary:
 - Document new API endpoints
 ```
 
-### Step 4: Update GitHub Issue Label
+### Step 4: Update Work-Item State
 
 Based on validation results:
 
 **If validation fails** (automated checks fail, critical issues found):
 ```bash
-gh issue edit <number> --add-label "validation-failed" --remove-label "in-progress"
+bash .claude/scripts/tracker.sh set-state <id> validation-failed in-progress
 ```
 
 **If validation passes** (all automated checks pass, ready for PR):
-- Keep `in-progress` label (will be updated to `pr-submitted` after PR creation)
+- Keep `in-progress` state (it will be transitioned to `pr-submitted` after PR creation)
 - Validation passing doesn't mean implementation is done - it means it's ready for code review via PR
 
 ## Working with Existing Context

--- a/.claude/tracker.example.json
+++ b/.claude/tracker.example.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Tracker config for the workflow skills. Copy this file to .claude/tracker.json (which is gitignored) and edit. The .json file overrides this example; if neither exists, the default backend is 'github' using the gh CLI's default repo context.",
+  "tracker": "github",
+  "github": {
+    "_comment": "When tracker='github', the 'gh' CLI's default repo context is used. Run 'gh repo set-default' to pin it if needed. owner/repo here are informational only at the moment - the adapter does not yet enforce them. Authenticate with 'gh auth login'."
+  },
+  "azure-devops": {
+    "_comment": "When tracker='azure-devops' (planned for PR 2). Set the organization and project. Authenticate with 'az login' and 'az devops configure --defaults organization=https://dev.azure.com/<org> project=<project>'. state_transitions optionally maps a neutral workflow state to an Azure DevOps typed State transition; tags are always added/removed regardless.",
+    "organization": "https://dev.azure.com/YOUR-ORG",
+    "project": "YOUR-PROJECT",
+    "state_transitions": {
+      "research-in-progress": { "state": "Active" },
+      "in-progress": { "state": "Active" },
+      "pr-submitted": { "state": "Resolved" },
+      "pr-merged": { "state": "Closed" }
+    }
+  },
+  "none": {
+    "_comment": "When tracker='none', the workflow skills operate without an issue tracker: state-update calls are no-ops, query calls return empty JSON. Use this for greenfield projects or local-only work."
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Cross-vendor review user profiles (endpoint URLs may identify private Azure resources)
 .claude/skills/cross-review/profiles.json
 
+# Tracker config (user-specific; may identify private orgs / projects)
+.claude/tracker.json
+
 # Ralph runtime state
 .ralph/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,19 +47,23 @@ Fill in as the project gains them (package manager, formatters and linters, test
 - Reference code with line numbers: `path/to/file.ts:42`; use `#L50-L75` for ranges in links.
 - Keep instruction files (this file and CLAUDE.md) lean and hand-written, roughly 150 to 200 lines maximum. Generic or auto-generated guidance measurably reduces task success, so write only specific, load-bearing rules.
 
-## GitHub issue conventions
+## Work-item / issue conventions
 
-- Use navigable links for file references in issues, not just code-highlighted text.
+These apply to any tracker the project uses (GitHub Issues, Azure DevOps work items, GitLab issues, and so on).
+
+- Use navigable links for file references in work items, not just code-highlighted text.
   - Good: `[config.py](src/backend/config.py)` (clickable)
   - Avoid: `` `config.py` `` (highlighted but not navigable)
 - Link formats: relative `[config.py](src/backend/config.py)`; with line `[config.py:50](src/backend/config.py#L50)`; with range `[config.py:50-75](src/backend/config.py#L50-L75)`.
 
-## GitHub issue label lifecycle
+## Workflow state lifecycle
 
-Each workflow step updates issue labels to track progress:
+The workflow assumes an issue tracker (GitHub Issues, Azure DevOps work items, GitLab issues, and so on), but skills talk to it through a thin adapter at [.claude/scripts/tracker.sh](.claude/scripts/tracker.sh), so any backend can plug in. See [docs/tracker-portability.md](docs/tracker-portability.md) for the contract and supported backends.
+
+Each workflow step transitions a work item through these neutral states:
 
 ```
-New issue
+New work item
   ↓ research step
 research-in-progress → research-complete
   ↓ planning step
@@ -70,7 +74,7 @@ in-progress
 validation-failed OR pr-submitted
 ```
 
-Label meanings:
+State meanings:
 - `research-in-progress`: research underway
 - `research-complete`: research done, ready for planning
 - `planning-in-progress`: plan being created
@@ -79,6 +83,11 @@ Label meanings:
 - `validation-failed`: implementation failed validation
 - `implementation-failed`: implementation could not be completed
 - `pr-submitted`: PR created, awaiting review
+
+How each backend stores the state:
+- **GitHub**: labels with these exact names (1:1).
+- **Azure DevOps**: Tags (free-form, same names), optionally with typed State transitions (see [.claude/tracker.example.json](.claude/tracker.example.json)).
+- **`none`**: no state tracking; skills proceed without an issue tracker.
 
 ## Build and test commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Claude-Code-specific guidance. The shared, tool-agnostic project rules live in [
 
 ## Workflow skills
 
-Each workflow stage in [AGENTS.md](AGENTS.md) is an explicit-invocation skill in [.claude/skills/](.claude/skills/) (the Agent Skills open standard, so the same files are also picked up by Copilot CLI and other compatible tools). Invoking one creates the `flow/` artifacts and, when given a GitHub issue URL or number, updates the issue labels automatically. Each sets `disable-model-invocation: true`, so it runs only when you invoke it explicitly, never autonomously.
+Each workflow stage in [AGENTS.md](AGENTS.md) is an explicit-invocation skill in [.claude/skills/](.claude/skills/) (the Agent Skills open standard, so the same files are also picked up by Copilot CLI and other compatible tools). Invoking one creates the `flow/` artifacts and, when given a tracker URL or work-item id, transitions the tracker state automatically (via [.claude/scripts/tracker.sh](.claude/scripts/tracker.sh); see [docs/tracker-portability.md](docs/tracker-portability.md) for the supported backends). Each sets `disable-model-invocation: true`, so it runs only when you invoke it explicitly, never autonomously.
 
 | Stage | Command | Artifact |
 |---|---|---|

--- a/docs/tracker-portability.md
+++ b/docs/tracker-portability.md
@@ -1,0 +1,105 @@
+# Tracker portability
+
+The workflow skills (`/research-requirements`, `/create-plan`, `/implement-plan`, `/validate-plan`, `/describe-pr`, `/handle-pr-feedback`, etc.) are designed to drive a project from "issue / work item" through "merged PR / merge request", updating tracker state at each stage. Different teams use different trackers (GitHub Issues, Azure DevOps work items, GitLab issues, Jira, or nothing at all), so the skills do not call any tracker's CLI directly. They call a thin adapter at [.claude/scripts/tracker.sh](../.claude/scripts/tracker.sh), which dispatches to whichever backend you've configured.
+
+This file explains the contract, the supported backends, the neutral workflow-state vocabulary, and how to configure a project.
+
+## The contract
+
+The adapter exposes a small set of subcommands - the contract every backend must satisfy. Skills call them as `bash .claude/scripts/tracker.sh <subcommand> <args>`.
+
+### Issue / work-item subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `view <id> [--json fields]` | Fetch a work item as JSON. Default fields cover title, body, state, comments. |
+| `set-state <id> <new> [<old>]` | Transition the work item to a new neutral state (see vocabulary below); optionally remove a previous state. |
+| `comment <id> <text>` | Post a comment on the work item. |
+
+### PR / merge-request subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `pr-current [--json fields]` | Fetch the PR for the current branch. |
+| `pr-view <id> [--json fields]` | Fetch a PR by id. |
+| `pr-diff <id>` | Print the PR diff. |
+| `pr-edit-body <id> <body-file>` | Replace the PR description from a file. |
+| `pr-comment <id> <text>` | Post a comment on the PR. |
+| `pr-list-open` | List recent open PRs (JSON). |
+| `pr-reviews <id>` | Fetch reviews on a PR. |
+| `pr-review-comments <id>` | Fetch inline review comments. |
+| `pr-decision <id>` | Fetch the PR review decision (APPROVED / CHANGES_REQUESTED / etc.). |
+| `pr-closing-issues <id>` | List the work-item ids this PR will close. |
+
+### Utility
+
+| Subcommand | Purpose |
+|---|---|
+| `repo-info` | Owner + repo name (or backend equivalent) as JSON. |
+| `backend` | Print the active backend name. |
+
+## Neutral workflow-state vocabulary
+
+States are the same strings every tracker sees. Backends translate them to native concepts.
+
+| Neutral state | Meaning |
+|---|---|
+| `research-in-progress` | Research is underway. |
+| `research-complete` | Research is done; ready for planning. |
+| `planning-in-progress` | A plan is being authored. |
+| `ready-for-dev` | Plan approved; ready to implement. |
+| `in-progress` | Development is underway. |
+| `validation-failed` | Implementation failed the validation gate. |
+| `implementation-failed` | Implementation could not be completed. |
+| `pr-submitted` | PR is open and awaiting review. |
+| `pr-merged` | PR is merged; work is done. |
+
+## Supported backends
+
+### `github` (default; fully wired)
+
+Uses the `gh` CLI's default repo context. States become GitHub **labels** with the same names. Run `gh auth login` and (if needed) `gh repo set-default`.
+
+Example mapping (1:1):
+
+```
+neutral set-state <id> research-in-progress  ->  gh issue edit <id> --add-label "research-in-progress"
+neutral set-state <id> research-complete research-in-progress  ->  gh issue edit <id> --add-label "research-complete" --remove-label "research-in-progress"
+```
+
+### `azure-devops` (planned for PR 2; currently a stub)
+
+States become Azure DevOps **Tags** (free-form, kept as-is). Optionally, the config can map specific neutral states to typed **State** transitions (`New` -> `Active` -> `Resolved` -> `Closed`); see the `state_transitions` block in [.claude/tracker.example.json](../.claude/tracker.example.json).
+
+Authentication: `az login` and `az devops configure --defaults organization=<org> project=<project>`.
+
+### `none` (tracker-less projects)
+
+Skills work without a tracker. Mutating calls are no-ops (logged); query calls return empty JSON. Suitable for greenfield work or local-only projects.
+
+## Configuration
+
+1. Copy the template:
+
+   ```bash
+   cp .claude/tracker.example.json .claude/tracker.json
+   ```
+
+   `.claude/tracker.json` is gitignored so each contributor can pick their own backend.
+
+2. Edit `.claude/tracker.json`: set `"tracker"` to one of `"github"`, `"azure-devops"`, or `"none"`, and fill in the backend-specific block. Authenticate the corresponding CLI (`gh` / `az`) if needed.
+
+3. Override per-invocation via env var if you want a one-off:
+
+   ```bash
+   TRACKER_BACKEND=none bash .claude/scripts/tracker.sh view 1
+   ```
+
+## What is NOT in scope here
+
+A few GitHub-specific behaviors deliberately remain in the skills as GitHub examples (with a note), because they have no neat tracker-neutral analog yet:
+
+- The `@claude` PR-review handshake in `/handle-pr-feedback` (driven by the Claude Code GitHub Action) - GitHub Actions only.
+- GitHub permalink generation in `/research-codebase` for inline file links - the URL shape is GitHub-specific.
+
+A future PR can lift these into the adapter (or document non-GitHub equivalents) once the backends settle.


### PR DESCRIPTION
## Summary

Abstract the issue tracker (and PR / merge-request) operations behind a thin adapter at [.claude/scripts/tracker.sh](.claude/scripts/tracker.sh), and refactor the 9 GitHub-coupled workflow skills to call it. Behaviour is identical to today (the `github` backend is fully wired); `azure-devops` lands as a stub for PR 2; a `none` backend supports tracker-less projects.

This is PR 1 of a two-PR series unblocking the workflow for non-GitHub trackers (Azure DevOps work items, GitLab issues, …) and a future plugin packaging.

## Changes

### New

- `.claude/scripts/tracker.sh` - 15 subcommands covering work-item and PR operations: `view`, `set-state`, `comment`, `pr-current`, `pr-view`, `pr-diff`, `pr-edit-body`, `pr-comment`, `pr-list-open`, `pr-reviews`, `pr-review-comments`, `pr-decision`, `pr-closing-issues`, `repo-info`, `backend`.
- `.claude/tracker.example.json` - committed template. Copy to `.claude/tracker.json` (gitignored) and set `"tracker": "github" | "azure-devops" | "none"`.
- `docs/tracker-portability.md` - the contract, the neutral state vocabulary, supported backends, and config instructions.

### Refactored (9 skills, every `gh issue/pr/repo/api` call now routes through the adapter)

- Issue side: `research-requirements`, `research-codebase`, `create-plan`, `implement-plan`, `validate-plan`.
- PR side: `describe-pr`, `handle-pr-feedback`.
- Handoff: `create-handoff`, `resume-handoff` (prose only - the `gh-<id>` filename prefix is kept as a stable repo-wide convention regardless of tracker).
- Unchanged (already tracker-agnostic): `commit`, `autonomous-commit`, `iterate-plan`.

### Neutralised wording

- `AGENTS.md`: `## GitHub issue conventions` → `## Work-item / issue conventions`; `## GitHub issue label lifecycle` → `## Workflow state lifecycle`; neutral state names preserved 1:1 with existing GitHub labels.
- `CLAUDE.md`: workflow-skills intro now talks about "tracker URL or work-item id" rather than "GitHub issue URL or number".
- Argument-hints: `[github-issue-url-*]` → `[issue-url-*]` / `[issue-url-or-id]`.

### Deliberately deferred (flagged with notes in skill bodies)

- `/handle-pr-feedback`'s `@claude` bot filter (GitHub Actions only).
- `/describe-pr`'s `gh repo set-default` setup hint.
- `/research-codebase`'s GitHub permalink URL shape (Azure DevOps URL shown as a substitute).

## Cross-tracker behaviour

| Backend | State storage | Auth | Status |
|---|---|---|---|
| `github` | labels (1:1 with neutral names) | `gh auth login` | fully wired |
| `azure-devops` | Tags + optional typed State transitions | `az login` | stub, PR 2 |
| `none` | nothing (mutations are no-ops, queries return `{}`) | none | usable |

Override at runtime: `TRACKER_BACKEND=none bash .claude/scripts/tracker.sh view 1`.

## Test Plan

- [x] `bash -n .claude/scripts/tracker.sh` - syntax OK.
- [x] `jq -e .tracker .claude/tracker.example.json` - JSON valid; default `github`.
- [x] `bash .claude/scripts/tracker.sh backend` prints `github`.
- [x] `TRACKER_BACKEND=none bash .claude/scripts/tracker.sh view 1` returns `{}`; `set-state` logs INFO and exits 0.
- [x] `grep -rnE '\`gh (issue|pr|repo|api)\b' .claude/skills/*/SKILL.md` - only `gh repo set-default` remains (the documented setup hint).
- [ ] On `github`: invoke `/research-requirements <real-issue-url>` and verify the work item transitions through `research-in-progress` → `research-complete` (labels on the issue).
- [ ] On `github`: invoke `/create-plan <real-issue-url>` and verify the state transitions through `planning-in-progress` → `ready-for-dev`.
- [ ] On `none`: copy `.claude/tracker.example.json` to `.claude/tracker.json`, set `"tracker": "none"`, invoke any workflow skill, and confirm it proceeds without tracker calls.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: template repo, no test suite; bash/jq validated)
- [x] Documentation updated ([docs/tracker-portability.md](docs/tracker-portability.md), `AGENTS.md`, `CLAUDE.md`)

## Context

- Follows the issue raised about Azure DevOps task workflows. The contract is in place after this PR; **PR 2** will add the `azure-devops` backend implementation (Entra ID via `az login`, Tag transitions, optional typed State mapping per the `state_transitions` block in the config).
- Unblocks future plugin packaging - the adapter belongs with the plugin; per-project tracker config (`.claude/tracker.json`) stays on the user side.
- Follows T1.1 (#31), T2.2 (#32), T1.3 (#33), gitignore-tests (#34).
