### PR TITLE
Add Flow plugin scaffolding (plugin.json, marketplace, bin/tracker, /flow:init, README)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "flow",
+  "owner": {
+    "name": "corticalstack"
+  },
+  "plugins": [
+    {
+      "name": "flow",
+      "source": ".",
+      "description": "A cross-tool agentic-coding workflow toolkit (12 workflow skills + optional cross-vendor review + tracker abstraction)."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "flow",
+  "displayName": "Flow",
+  "version": "0.1.0",
+  "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
+  "author": {
+    "name": "corticalstack"
+  },
+  "homepage": "https://github.com/corticalstack/flow",
+  "repository": "https://github.com/corticalstack/flow",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "skills",
+    "agentic-coding",
+    "research-plan-implement-validate",
+    "cross-vendor-review",
+    "tracker-abstraction",
+    "agent-skills",
+    "agents-md"
+  ],
+  "skills": ".claude/skills/"
+}

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: init
+description: Bootstrap a new project with the Flow workflow - creates AGENTS.md from the template, creates .claude/tracker.json from the example, and optionally sets up cross-vendor review profiles. Run once per project after installing the Flow plugin. Explicit-only; do not auto-fire.
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write
+---
+
+# Flow init
+
+You are bootstrapping the **current user project** (the directory at `${CLAUDE_PROJECT_DIR}`) with Flow's workflow conventions and config templates. Read templates from the plugin install at `${CLAUDE_PLUGIN_ROOT}`. Treat this as an **interactive setup wizard**: ask before each write, never overwrite an existing file.
+
+## Steps
+
+### 1. AGENTS.md
+
+Check if `${CLAUDE_PROJECT_DIR}/AGENTS.md` exists.
+
+- **If it does NOT exist:**
+  - Read `${CLAUDE_PLUGIN_ROOT}/docs/AGENTS.md.template`.
+  - Ask the user: *"I'll create AGENTS.md at your project root from Flow's template. It has a `[Replace this section ...]` placeholder for the project overview - I can fill it in if you give me a one-paragraph description of this project, or leave the placeholder for you to edit later. What would you like?"*
+  - Resolve the placeholder if the user gives a description, then write the content to `${CLAUDE_PROJECT_DIR}/AGENTS.md`.
+
+- **If it DOES exist:**
+  - Read it. Tell the user: *"AGENTS.md already exists. Flow expects (1) the feature-branch requirement, (2) the research / plan / implement / validate stages with `flow/` artifacts, (3) the workflow-state vocabulary, (4) a pointer to the tracker adapter. The template is at `${CLAUDE_PLUGIN_ROOT}/docs/AGENTS.md.template` - compare and merge anything missing."*
+  - Do NOT overwrite.
+
+### 2. Tracker config
+
+Check if `${CLAUDE_PROJECT_DIR}/.claude/tracker.json` exists.
+
+- **If it does NOT exist:**
+  - Ask the user: *"Which issue tracker does this project use? `github`, `azure-devops`, or `none`? I'll create `.claude/tracker.json` from the Flow example with your choice as the active backend."*
+  - Read `${CLAUDE_PLUGIN_ROOT}/.claude/tracker.example.json`.
+  - Build the project's `.claude/tracker.json` with `"tracker": "<user-choice>"` and the corresponding backend block populated as much as you can from the example (keep the other backend blocks as inert reference - the adapter only reads the active one).
+  - Create the `${CLAUDE_PROJECT_DIR}/.claude/` directory if it does not exist, then write the file.
+  - Then per backend:
+    - `github`: tell the user to confirm `gh auth login` is done.
+    - `azure-devops`: warn that the backend is currently a stub (PR 2 pending) - tag / state-transition writes will not yet happen.
+    - `none`: tell the user nothing more is needed; mutating tracker calls become no-ops, queries return empty JSON.
+
+- **If it DOES exist:**
+  - Tell the user: *".claude/tracker.json already exists; leaving it alone. If you want to change backend, edit it directly - see `${CLAUDE_PLUGIN_ROOT}/.claude/tracker.example.json` for the schema."*
+
+### 3. Cross-vendor review (optional)
+
+Ask: *"Want to set up cross-vendor review now? It's optional - you can do it later. (yes / no)"*
+
+- If **yes**:
+  - Check if `${CLAUDE_PROJECT_DIR}/.claude/skills/cross-review/profiles.json` exists.
+  - If not, read `${CLAUDE_PLUGIN_ROOT}/.claude/skills/cross-review/profiles.example.json` and write a copy to `${CLAUDE_PROJECT_DIR}/.claude/skills/cross-review/profiles.json` (creating the directory if needed).
+  - Tell the user to edit the file with their Foundry endpoint + deployment, GitHub Models model id, or Copilot CLI model, then run `az login`, `gh auth login`, or `copilot auth login` as needed.
+
+### 4. Summary
+
+Print a short summary of what was created and any pending user actions. End with:
+
+> Try `/flow:research-requirements <issue-url-or-description>` to kick off the workflow.
+
+## Out of scope
+
+This skill does not:
+- Commit anything (no `git add` / `git commit`).
+- Run authentication flows (`gh auth login`, `az login`, `copilot auth login`) - the user does those.
+- Install prerequisites (`jq`, `curl`, `gh`, `az`, `copilot`) - the user installs them.
+- Overwrite existing `AGENTS.md` or `tracker.json` files.
+
+## Errors
+
+- If the project is not a git repo, the workflow skills assume git is in use. Suggest `git init` if applicable, but do not run it automatically.
+- If a write fails (permissions, etc.), print the exact error and stop.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,102 @@
-# [Your Project Name Here]
+# Flow
 
-> **⚠️ POST-TEMPLATE SETUP REQUIRED**
->
-> You've created a project from the `flow` template. **Replace this README** with your project documentation after setup.
->
-> **Complete Instructions**: [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md)
+A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research → plan → implement → validate → review → ship), an optional cross-vendor code-review skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, GitLab issues, …) - all behind the [Agent Skills open standard](https://agentskills.io/specification) so the same files work in Claude Code and GitHub Copilot CLI.
 
----
+## Install
 
-## About This Template
+### Claude Code (plugin, recommended)
 
-This project uses the **Flow** template - a structured workflow for AI-assisted development with manual step-by-step commands or fully autonomous multi-issue processing.
-
----
-
-## Workflow Overview
-
-**Manual (step-by-step):**
-
-[/research-requirements](.claude/skills/research-requirements/SKILL.md) → [/create-plan](.claude/skills/create-plan/SKILL.md) → [/implement-plan](.claude/skills/implement-plan/SKILL.md) → [/validate-plan](.claude/skills/validate-plan/SKILL.md) → [/cross-review](.claude/skills/cross-review/SKILL.md) (optional, advisory) → [/commit](.claude/skills/commit/SKILL.md) → Push & PR → [/describe-pr](.claude/skills/describe-pr/SKILL.md) → Review → [/handle-pr-feedback](.claude/skills/handle-pr-feedback/SKILL.md) (if needed) → Merge
-
-**Autonomous (unattended):**
-```bash
-./scripts/ralph-autonomous.sh --monitor  # Launch with live dashboard
+```
+/plugin marketplace add corticalstack/flow
+/plugin install flow@flow
+/flow:init
 ```
 
-Processes up to 10 issues automatically with live monitoring, state management, and retry logic.
+`/flow:init` is an interactive bootstrap that creates `AGENTS.md` at your project root from Flow's template, creates `.claude/tracker.json` from the example, and optionally sets up cross-vendor review profiles.
 
-See [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md) for complete documentation.
+### GitHub Copilot CLI
 
----
+```
+gh skill install corticalstack/flow                                  # interactive picker (recommended)
+gh skill install corticalstack/flow .claude/skills/create-plan       # one specific skill
+```
+
+Then drop in an `AGENTS.md` (see [docs/AGENTS.md.template](docs/AGENTS.md.template)) and configure `.claude/tracker.json` (see [.claude/tracker.example.json](.claude/tracker.example.json)).
+
+### Cloned repo (template-style, alternative)
+
+If you want the entire repo - including the optional Ralph autonomous-loop scripts under `scripts/` and worked examples:
+
+```
+gh repo create my-project --template corticalstack/flow
+```
+
+See [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md) for post-clone setup.
+
+## What you get
+
+**Workflow skills (12):**
+
+- `/flow:research-requirements`, `/flow:research-codebase` - structured research phase
+- `/flow:create-plan`, `/flow:iterate-plan` - implementation planning
+- `/flow:implement-plan`, `/flow:validate-plan` - execution + quality gate
+- `/flow:commit`, `/flow:autonomous-commit` - commit hygiene
+- `/flow:describe-pr`, `/flow:handle-pr-feedback` - PR description + review-feedback loop
+- `/flow:create-handoff`, `/flow:resume-handoff` - cross-session continuity
+
+**Optional cross-vendor review:**
+
+- `/flow:cross-review` - a configurable OAuth-only review against Azure AI Foundry, GitHub Models, or GitHub Copilot CLI. A model from a different vendor reads the diff vs `main` and surfaces high/critical findings - advisory only, never edits code. See [docs/cross-vendor-review.md](docs/cross-vendor-review.md).
+
+**Tracker abstraction:**
+
+- `bin/tracker` (PATH-wrapper) + `.claude/scripts/tracker.sh` (the adapter)
+- `github` backend wired (uses `gh`); `azure-devops` backend stub; `none` for tracker-less projects
+- Configurable per-project via `.claude/tracker.json`. See [docs/tracker-portability.md](docs/tracker-portability.md).
+
+**Bootstrap helper:**
+
+- `/flow:init` - creates `AGENTS.md`, `.claude/tracker.json`, and optional `cross-review/profiles.json` from templates.
+
+## Workflow overview
+
+```
+/flow:research-requirements
+       ↓
+/flow:create-plan
+       ↓
+/flow:implement-plan        ←─── iterate per phase
+       ↓
+/flow:validate-plan          (quality gate)
+       ↓
+/flow:cross-review           (optional, advisory)
+       ↓
+/flow:commit
+       ↓
+Push  &  PR
+       ↓
+/flow:describe-pr
+       ↓
+Review (human or @claude)
+       ↓
+/flow:handle-pr-feedback     (if changes requested)
+       ↓
+Merge
+```
+
+Each stage drops a durable markdown artifact under `flow/research/`, `flow/plans/`, `flow/prs/`, or `flow/reviews/`, so the next agent (or future you) can pick up cleanly.
+
+## Docs
+
+- [docs/tracker-portability.md](docs/tracker-portability.md) - the tracker adapter contract, neutral state vocabulary, supported backends.
+- [docs/cross-vendor-review.md](docs/cross-vendor-review.md) - `/flow:cross-review` setup, backends, caveats.
+- [docs/AGENTS.md.template](docs/AGENTS.md.template) - the `AGENTS.md` `/flow:init` ships.
+- [docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md) - for the cloned-repo path.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
+MIT - see [LICENSE](LICENSE).
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
----
-
-**Remember**: This README is a template placeholder. Replace it with documentation specific to your project after completing setup!
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/bin/tracker
+++ b/bin/tracker
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Thin PATH wrapper around .claude/scripts/tracker.sh.
+#
+# When this plugin is installed in Claude Code, bin/ is automatically added
+# to the Bash tool's PATH, so skill bodies can call `tracker <subcommand>`
+# without a path prefix. When the repo is cloned directly (template-style),
+# the same wrapper works via `./bin/tracker <subcommand>`.
+#
+# Resolution: this wrapper sits at <plugin-root>/bin/tracker; the real
+# adapter is at <plugin-root>/.claude/scripts/tracker.sh. We resolve the
+# absolute path of *this* file's directory, then exec the adapter relative
+# to it.
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${HERE}/../.claude/scripts/tracker.sh" "$@"

--- a/docs/AGENTS.md.template
+++ b/docs/AGENTS.md.template
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+Project instructions for any AI coding agent (Claude Code, OpenAI Codex, GitHub Copilot CLI, Cursor, Gemini CLI, and other AGENTS.md-compatible tools). This file holds the tool-agnostic rules.
+
+## Project overview
+
+[Replace this section with a one-paragraph description of YOUR project: what it does, who it is for, and any relevant context.]
+
+## Critical: feature-branch requirement
+
+**Never make changes directly on the `main` branch. No exceptions.**
+
+- Create a feature branch before generating or modifying ANY file: code, tests, docs, or workflow artifacts under `flow/`.
+- Every change reaches `main` through a pull request, never a direct commit.
+- Before starting any step that writes files (research, planning, implementation, validation):
+  1. Check the current branch: `git branch --show-current`
+  2. If on `main`, create a feature branch immediately: `git checkout -b feature/<name>`
+  3. Only proceed once on a feature branch.
+- If you find yourself on `main` with changes, stop, create a feature branch, and move the changes there before continuing.
+
+Why: `main` must stay stable and deployable, every change needs review, and accidental `main` commits disrupt the workflow.
+
+## Branch naming
+
+- Features: `feature/<issue-number>-<brief-description>`
+- Bug fixes: `bugfix/<issue-number>-<brief-description>`
+- Always branch from `main`; never commit to `main` directly.
+
+## Workflow: research, plan, implement, validate
+
+Stage the work and reset context between stages. Each stage leaves a durable artifact under `flow/`:
+
+1. **Research**: understand before changing. Output a markdown file in `flow/research/`.
+2. **Plan**: write an implementation plan before coding. Output a markdown file in `flow/plans/`.
+3. **Implement**: execute the plan in phases, pausing for verification between phases.
+4. **Validate**: a quality gate before committing. Run the existing test suite, confirm the implementation matches the plan, and catch issues before they reach version control.
+
+Pause for human review at the research and plan boundaries; those are the highest-leverage review points.
+
+## Project conventions
+
+[Fill in as the project gains them: package manager, formatters and linters, testing approach. Keep entries specific and load-bearing.]
+
+## Documentation conventions
+
+- Use navigable links for file references: `[filename](path/to/file)`, not bare backticks.
+- Reference code with line numbers: `path/to/file.ts:42`; use `#L50-L75` for ranges in links.
+- Keep instruction files lean and hand-written, roughly 150 to 200 lines maximum. Generic or auto-generated guidance measurably reduces task success.
+
+## Work-item / issue conventions
+
+These apply to any tracker the project uses (GitHub Issues, Azure DevOps work items, GitLab issues, and so on).
+
+- Use navigable links for file references in work items, not just code-highlighted text.
+  - Good: `[config.py](src/backend/config.py)` (clickable)
+  - Avoid: `` `config.py` `` (highlighted but not navigable)
+- Link formats: relative `[config.py](src/backend/config.py)`; with line `[config.py:50](src/backend/config.py#L50)`; with range `[config.py:50-75](src/backend/config.py#L50-L75)`.
+
+## Workflow state lifecycle
+
+The Flow workflow assumes an issue tracker (GitHub Issues, Azure DevOps work items, GitLab issues, and so on) but skills talk to it through a thin adapter so any backend can plug in. The adapter is bundled with the Flow plugin as `bin/tracker` (PATH-resolvable after install) or at `.claude/scripts/tracker.sh` if the repo was cloned directly. See the Flow plugin's `docs/tracker-portability.md` for the contract and supported backends.
+
+Configure the tracker via `.claude/tracker.json` in your project root. The `/flow:init` skill creates one for you from the example template.
+
+Each workflow step transitions a work item through these neutral states:
+
+```
+New work item
+  ↓ research step
+research-in-progress → research-complete
+  ↓ planning step
+planning-in-progress → ready-for-dev
+  ↓ implementation step
+in-progress
+  ↓ validation (on failure) OR PR creation (on success)
+validation-failed OR pr-submitted
+```
+
+State meanings:
+- `research-in-progress`: research underway
+- `research-complete`: research done, ready for planning
+- `planning-in-progress`: plan being created
+- `ready-for-dev`: has an approved plan, ready to implement
+- `in-progress`: development underway
+- `validation-failed`: implementation failed validation
+- `implementation-failed`: implementation could not be completed
+- `pr-submitted`: PR created, awaiting review
+
+How each backend stores the state:
+- **GitHub**: labels with these exact names (1:1).
+- **Azure DevOps**: Tags (free-form, same names), optionally with typed State transitions.
+- **`none`**: no state tracking; skills proceed without an issue tracker.
+
+## Build and test commands
+
+```bash
+# Fill in this section with your project's actual build / test commands.
+# Examples:
+#   uv run pytest          # Python
+#   npm test               # Node.js
+#   make test              # generic
+#   cargo test             # Rust
+#   go test ./...          # Go
+```


### PR DESCRIPTION
## Summary

Convert this repo into an **installable Claude Code plugin** (and a `gh skill install` source for GitHub Copilot CLI) while keeping it usable as a clone-the-repo template. After this lands, a fresh project can pull in the entire Flow workflow with:

```
/plugin marketplace add corticalstack/flow
/plugin install flow@flow
/flow:init
```

Implements **step 5 of the rename plan** (final step). Follows #35 (tracker abstraction) and #36 (`claude-code-flow` → `flow` content rename).

## Changes

### New files

- **`.claude-plugin/plugin.json`** - manifest declaring the `flow` plugin v0.1.0; `skills` field points at `.claude/skills/` so the 13 existing skill directories are picked up.
- **`.claude-plugin/marketplace.json`** - self-hosted marketplace catalog so `/plugin marketplace add corticalstack/flow` resolves; the repo root is the plugin source.
- **`bin/tracker`** (mode `100755`) - thin PATH wrapper around `.claude/scripts/tracker.sh`. Auto-added to the Bash tool's PATH when the plugin is installed; works as `./bin/tracker` for cloned repos.
- **`.claude/skills/init/SKILL.md`** - interactive bootstrap skill (`/flow:init`). Creates `AGENTS.md` from the template, `.claude/tracker.json` from the example, optionally `cross-review/profiles.json`. Never overwrites; always asks before writing.
- **`docs/AGENTS.md.template`** - the `AGENTS.md` baseline `/flow:init` copies into a fresh project, with a `[Replace this section ...]` placeholder for the project overview.

### Rewritten

- **`README.md`** - now focused on Flow as a cross-tool toolkit. Lead with install instructions for Claude Code (plugin), Copilot CLI (`gh skill install`), and the cloned-repo alternative. Workflow overview, what-you-get section, doc links. The previous `POST-TEMPLATE SETUP REQUIRED` placeholder is gone (confusing for repo visitors; template-clone users now see a useful Flow README that they replace themselves).

## How the install works

| Audience | Command(s) | Result |
|---|---|---|
| Claude Code user | `/plugin marketplace add corticalstack/flow` then `/plugin install flow@flow` then `/flow:init` | Plugin loaded; skills invocable as `/flow:<skill>`; `AGENTS.md` + `.claude/tracker.json` created in the user's project |
| Copilot CLI user | `gh skill install corticalstack/flow` (interactive) | Each picked skill is copied into `.claude/skills/` (or `.agents/skills/`); `AGENTS.md` + `tracker.json` must be set up manually from the templates |
| Clone-the-repo (Ralph users) | `gh repo create my-project --template corticalstack/flow` | Full repo including Ralph scripts under `scripts/`, ready to use |

## Verified locally

- [x] `bash -n bin/tracker` - syntax OK; mode `100755`.
- [x] `bash -n .claude/scripts/tracker.sh` - still valid after wrapper added.
- [x] `jq -e .name .claude-plugin/plugin.json` - valid JSON; `name=flow`, `skills=.claude/skills/`.
- [x] `jq -e .name .claude-plugin/marketplace.json` - valid JSON; `name=flow`, 1 plugin entry.
- [x] `PATH="$(pwd)/bin:$PATH" tracker backend` → prints `github` (wrapper reaches the adapter).
- [x] `PATH="$(pwd)/bin:$PATH" TRACKER_BACKEND=none tracker view 1` → prints `{}` (env override flows through).

## Test Plan (post-merge, in a fresh repo)

- [ ] In a fresh git repo: `/plugin marketplace add corticalstack/flow` then `/plugin install flow@flow`. Confirm the marketplace adds and the plugin installs without errors.
- [ ] Restart Claude Code; verify `/flow:` skills appear in autocomplete (`/flow:research-requirements`, `/flow:create-plan`, `/flow:cross-review`, `/flow:init`, etc.).
- [ ] Run `/flow:init` and walk through the interactive setup. Confirm `AGENTS.md` and `.claude/tracker.json` are created at the project root.
- [ ] In a Bash tool call: confirm `tracker backend` prints `github` (wrapper is on PATH).
- [ ] (Copilot CLI) `gh skill install corticalstack/flow` in a fresh repo; confirm picker lists skills, and a picked skill lands in `.claude/skills/<name>/`.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (N/A: no test suite; bash / jq / smoke validated)
- [x] Documentation updated (README rewritten; `docs/AGENTS.md.template` added; tracker-portability and cross-vendor-review docs unchanged but still apply)

## Context

- The plugin install path is the new primary distribution channel; the clone-the-repo path stays as an alternative for users who also want the Ralph autonomous-loop scripts.
- `/flow:init` uses `${CLAUDE_PLUGIN_ROOT}` (resolves to the plugin install dir) and `${CLAUDE_PROJECT_DIR}` (the user's project root) - both documented Claude Code plugin variables.
- Hooks are deliberately deferred for v1 (a SessionStart "no AGENTS.md" nag every session start becomes annoying; revisit if there's demand).
- After this lands and `/flow:init` is shaken out in a fresh repo, the next natural item is **PR 2 of the tracker series** (azure-devops backend implementation; contract is already in place).
