### PR TITLE
Wire azure-devops backend for tracker adapter (PR 2)

### DIFF
--- a/.claude/scripts/tracker.sh
+++ b/.claude/scripts/tracker.sh
@@ -125,10 +125,172 @@ gh_pr_closing_issues() { gh_require; gh pr view "$1" --json closingIssuesReferen
 gh_repo_info()       { gh_require; gh repo view --json owner,name; }
 
 # ----------------------------------------------------------------------------
-# Azure DevOps backend (stub - implemented in PR 2)
+# Azure DevOps backend
 # ----------------------------------------------------------------------------
-azdo_stub() {
-  abort "azure-devops backend is not implemented yet (PR 2). See docs/tracker-portability.md." 3
+# Auth: `az login` (Entra ID OAuth) plus, optionally,
+#   `az devops configure --defaults organization=https://dev.azure.com/<org> project=<project>`
+# to pin org / project. The `--detect` flag on PR / repo commands lets the CLI
+# infer org / project from the current git remote. The `azure-devops` extension
+# must be installed: `az extension add --name azure-devops`.
+azdo_require() {
+  command -v az >/dev/null 2>&1 \
+    || abort "'az' CLI not installed. Install Azure CLI and 'az extension add --name azure-devops'" 3
+}
+
+# Helper: remove a tag from a System.Tags string (semicolon-space separated).
+azdo_tags_remove() {
+  local tags="$1" rm_tag="$2" result="" t
+  [ -z "$tags" ] && { printf ''; return; }
+  local -a _arr=()
+  IFS=';' read -ra _arr <<< "$tags" || true
+  for t in "${_arr[@]:-}"; do
+    [ -z "$t" ] && continue
+    t="$(printf '%s' "$t" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    if [ -n "$t" ] && [ "$t" != "$rm_tag" ]; then
+      [ -z "$result" ] && result="$t" || result="$result; $t"
+    fi
+  done
+  printf '%s' "$result"
+}
+
+# Helper: add a tag to a System.Tags string (no duplicate).
+azdo_tags_add() {
+  local tags="$1" add_tag="$2" t
+  [ -z "$tags" ] && { printf '%s' "$add_tag"; return; }
+  local -a _arr=()
+  IFS=';' read -ra _arr <<< "$tags" || true
+  for t in "${_arr[@]:-}"; do
+    [ -z "$t" ] && continue
+    t="$(printf '%s' "$t" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ "$t" = "$add_tag" ] && { printf '%s' "$tags"; return; }
+  done
+  printf '%s; %s' "$tags" "$add_tag"
+}
+
+azdo_view() {
+  azdo_require
+  # No --json fields equivalent in az; --expand all returns the full item.
+  az boards work-item show --id "$1" --expand all --output json
+}
+
+azdo_set_state() {
+  azdo_require
+  local id="$1" new="$2" old="${3:-}"
+  local current new_tags mapped_state
+  current=$(az boards work-item show --id "$id" --query 'fields."System.Tags"' -o tsv 2>/dev/null || true)
+  new_tags="$current"
+  [ -n "$old" ] && new_tags=$(azdo_tags_remove "$new_tags" "$old")
+  new_tags=$(azdo_tags_add "$new_tags" "$new")
+  # Optional typed System.State transition from the config's state_transitions block.
+  mapped_state=""
+  if [ -f "$CONFIG" ]; then
+    mapped_state=$(jq -r --arg n "$new" '.["azure-devops"].state_transitions[$n].state // empty' "$CONFIG" 2>/dev/null || true)
+  fi
+  if [ -n "$mapped_state" ]; then
+    az boards work-item update --id "$id" --state "$mapped_state" --fields "System.Tags=$new_tags" --output json
+  else
+    az boards work-item update --id "$id" --fields "System.Tags=$new_tags" --output json
+  fi
+}
+
+azdo_comment() {
+  azdo_require
+  az boards work-item update --id "$1" --discussion "$2" --output json
+}
+
+azdo_pr_current() {
+  azdo_require
+  local branch
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || branch=""
+  [ -z "$branch" ] && abort "cannot detect current branch (not in a git repo?)" 2
+  az repos pr list --source-branch "refs/heads/$branch" --status active --output json --query '[0]'
+}
+
+azdo_pr_view() { azdo_require; az repos pr show --id "$1" --output json; }
+
+azdo_pr_diff() {
+  azdo_require
+  local id="$1" source target
+  source=$(az repos pr show --id "$id" --query sourceRefName -o tsv 2>/dev/null | sed 's|refs/heads/||')
+  target=$(az repos pr show --id "$id" --query targetRefName -o tsv 2>/dev/null | sed 's|refs/heads/||')
+  [ -z "$source" ] && abort "could not resolve PR $id source branch" 4
+  [ -z "$target" ] && abort "could not resolve PR $id target branch" 4
+  git fetch origin "$source" "$target" >/dev/null 2>&1 || true
+  git diff "origin/${target}...origin/${source}"
+}
+
+azdo_pr_edit_body() {
+  azdo_require
+  [ ! -f "$2" ] && abort "body file not found: $2" 2
+  az repos pr update --id "$1" --description "$(cat "$2")" --output json
+}
+
+# Resolve project + repository.id for a PR (needed by az devops invoke for thread ops).
+azdo_pr_resolve_repo() {
+  local id="$1" info
+  info=$(az repos pr show --id "$id" --output json 2>/dev/null) \
+    || abort "could not resolve PR $id" 4
+  _AZDO_PROJECT=$(printf '%s' "$info" | jq -r '.repository.project.name // empty')
+  _AZDO_REPO_ID=$(printf '%s' "$info" | jq -r '.repository.id // empty')
+  [ -z "$_AZDO_PROJECT" ] && abort "could not resolve repository.project.name for PR $id" 4
+  [ -z "$_AZDO_REPO_ID" ] && abort "could not resolve repository.id for PR $id" 4
+}
+
+azdo_pr_comment() {
+  azdo_require
+  local id="$1" text="$2" body_file
+  azdo_pr_resolve_repo "$id"
+  body_file="$(mktemp)"
+  trap 'rm -f "$body_file"' RETURN
+  jq -n --arg text "$text" '{comments: [{parentCommentId: 0, content: $text, commentType: 1}], status: 1}' > "$body_file"
+  az devops invoke \
+    --area git --resource pullRequestThreads \
+    --route-parameters "project=$_AZDO_PROJECT" "repositoryId=$_AZDO_REPO_ID" "pullRequestId=$id" \
+    --http-method POST --in-file "$body_file" --api-version 7.1 --output json
+}
+
+azdo_pr_list_open() { azdo_require; az repos pr list --status active --top 10 --output json; }
+
+azdo_pr_reviews() { azdo_require; az repos pr reviewer list --id "$1" --output json; }
+
+azdo_pr_review_comments() {
+  azdo_require
+  local id="$1"
+  azdo_pr_resolve_repo "$id"
+  az devops invoke \
+    --area git --resource pullRequestThreads \
+    --route-parameters "project=$_AZDO_PROJECT" "repositoryId=$_AZDO_REPO_ID" "pullRequestId=$id" \
+    --http-method GET --api-version 7.1 --output json
+}
+
+azdo_pr_decision() {
+  azdo_require
+  # ADO has no native reviewDecision; derive from reviewer-vote integers
+  # (REST 7.1): 10=approved, 5=approved-with-suggestions, 0=no-vote, -5=waiting, -10=rejected.
+  local votes rejections approvals
+  votes=$(az repos pr reviewer list --id "$1" --output json 2>/dev/null) || votes='[]'
+  rejections=$(printf '%s' "$votes" | jq '[.[] | select(.vote == -10)] | length')
+  approvals=$(printf '%s' "$votes" | jq '[.[] | select(.vote >= 5)] | length')
+  if [ "$rejections" -gt 0 ]; then
+    printf '{"reviewDecision":"CHANGES_REQUESTED"}\n'
+  elif [ "$approvals" -gt 0 ]; then
+    printf '{"reviewDecision":"APPROVED"}\n'
+  else
+    printf '{"reviewDecision":"REVIEW_REQUIRED"}\n'
+  fi
+}
+
+azdo_pr_closing_issues() {
+  azdo_require
+  # Returns work-item ids, one per line, to match the GitHub backend's behaviour.
+  az repos pr work-item list --id "$1" --output tsv --query '[].id'
+}
+
+azdo_repo_info() {
+  azdo_require
+  # {owner, project, name} - owner is the org name parsed from remoteUrl.
+  az repos show --detect --output json 2>/dev/null \
+    | jq '{owner: (.remoteUrl | split("/")[3]), project: .project.name, name: .name}'
 }
 
 # ----------------------------------------------------------------------------
@@ -171,7 +333,21 @@ case "$BACKEND" in
   azure-devops)
     case "$SUBCMD" in
       backend) echo azure-devops ;;
-      *) azdo_stub ;;
+      view) azdo_view "$@" ;;
+      set-state) azdo_set_state "$@" ;;
+      comment) azdo_comment "$@" ;;
+      pr-current) azdo_pr_current "$@" ;;
+      pr-view) azdo_pr_view "$@" ;;
+      pr-diff) azdo_pr_diff "$@" ;;
+      pr-edit-body) azdo_pr_edit_body "$@" ;;
+      pr-comment) azdo_pr_comment "$@" ;;
+      pr-list-open) azdo_pr_list_open ;;
+      pr-reviews) azdo_pr_reviews "$@" ;;
+      pr-review-comments) azdo_pr_review_comments "$@" ;;
+      pr-decision) azdo_pr_decision "$@" ;;
+      pr-closing-issues) azdo_pr_closing_issues "$@" ;;
+      repo-info) azdo_repo_info ;;
+      *) abort "unknown subcommand for azure-devops backend: $SUBCMD" 2 ;;
     esac
     ;;
 

--- a/docs/tracker-portability.md
+++ b/docs/tracker-portability.md
@@ -67,11 +67,25 @@ neutral set-state <id> research-in-progress  ->  gh issue edit <id> --add-label 
 neutral set-state <id> research-complete research-in-progress  ->  gh issue edit <id> --add-label "research-complete" --remove-label "research-in-progress"
 ```
 
-### `azure-devops` (planned for PR 2; currently a stub)
+### `azure-devops` (wired)
 
-States become Azure DevOps **Tags** (free-form, kept as-is). Optionally, the config can map specific neutral states to typed **State** transitions (`New` -> `Active` -> `Resolved` -> `Closed`); see the `state_transitions` block in [.claude/tracker.example.json](../.claude/tracker.example.json).
+States become Azure DevOps **Tags** (free-form, kept as-is - one tag per neutral-state name). Optionally, the config maps specific neutral states to typed **System.State** transitions (`New` -> `Active` -> `Resolved` -> `Closed`); see the `state_transitions` block in [.claude/tracker.example.json](../.claude/tracker.example.json). When a mapping exists, `set-state` updates both the Tag set and System.State in a single `az boards work-item update` call.
 
-Authentication: `az login` and `az devops configure --defaults organization=<org> project=<project>`.
+Setup:
+
+```bash
+az login                                                                  # Entra ID OAuth
+az extension add --name azure-devops                                      # required extension
+az devops configure --defaults organization=https://dev.azure.com/<org> project=<project>
+```
+
+Implementation notes:
+
+- `set-state` reads the current `System.Tags` string (semicolon-space separated, per the REST API 7.1 contract), removes the optional `<old-state>` tag if present, appends `<new-state>` (deduped), and writes the full replacement string back. The API replaces, not appends, so the helper round-trips the string.
+- `pr-comment` and `pr-review-comments` route through `az devops invoke` against the REST API 7.1 `pullRequestThreads` resource - the CLI has no dedicated subcommand for either.
+- `pr-decision` derives the equivalent of GitHub's `reviewDecision` from reviewer-vote integers (10 = approved, -10 = rejected, ...); returns `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` in a JSON envelope shaped like the GitHub one.
+- `pr-diff` is git-side (`git diff origin/<target>...origin/<source>`) because `az repos pr diff` does not exist.
+- `repo-info` returns `{owner, project, name}` (with `owner` parsed from the repo's `remoteUrl`) - note the extra `project` field vs the GitHub shape.
 
 ### `none` (tracker-less projects)
 


### PR DESCRIPTION
## Summary

Wire the `azure-devops` backend in `.claude/scripts/tracker.sh`. Until now the case in the dispatcher was a stub returning a clear error (from PR 1, #35); this PR fills it in with all 15 subcommands plumbed through `az boards`, `az repos pr`, and `az devops invoke`. Implements **PR 2 of the tracker-portability series**.

After this lands, an Azure-DevOps-based project can drop a `.claude/tracker.json` with `"tracker": "azure-devops"` and have the workflow skills drive ADO work items + PRs through the same neutral contract the GitHub backend uses.

## Changes

### `.claude/scripts/tracker.sh`

All 15 subcommands now have ADO implementations. Highlights:

| Op | ADO command |
|---|---|
| `view` | `az boards work-item show --expand all` |
| `set-state` | Read current `System.Tags`, remove optional old tag, add new tag (dedup), write back; optionally apply typed `System.State` transition from the `state_transitions` config block |
| `comment` | `az boards work-item update --discussion '...'` |
| `pr-current` | `az repos pr list --source-branch refs/heads/<branch> --status active` |
| `pr-view` | `az repos pr show --id <id>` |
| `pr-diff` | `git diff origin/<target>...origin/<source>` (no `az repos pr diff` exists) |
| `pr-edit-body` | `az repos pr update --id <id> --description "$(cat <file>)"` |
| `pr-comment` | `az devops invoke POST pullRequestThreads` (REST 7.1; no native CLI) |
| `pr-list-open` | `az repos pr list --status active --top 10` |
| `pr-reviews` | `az repos pr reviewer list --id <id>` |
| `pr-review-comments` | `az devops invoke GET pullRequestThreads` (REST 7.1) |
| `pr-decision` | Derived from reviewer-vote integers (10=approved, -10=rejected, …); returns JSON envelope matching the GitHub shape |
| `pr-closing-issues` | `az repos pr work-item list --output tsv` |
| `repo-info` | `az repos show --detect | jq '{owner, project, name}'` (org parsed from `remoteUrl`; ADO has no top-level org field) |
| `backend` | prints `azure-devops` |

Helpers added: `azdo_tags_add`, `azdo_tags_remove` - handle the **semicolon-space** separator that ADO's `System.Tags` uses (per REST API 7.1), with no-duplicate-add and safe removal regardless of position. 6/6 unit cases verified.

### `docs/tracker-portability.md`

Updated the `azure-devops` section: marked "wired", added a Setup block, and added implementation notes covering:
- the Tag semicolon-space format and the read-modify-write tag round-trip
- the `az devops invoke` routing for PR comments and inline review threads (no dedicated CLI)
- the vote-integer derivation of `reviewDecision`
- the `git`-side `pr-diff`
- the extra `project` field in `repo-info` vs the GitHub shape

## Setup (one-time, for users adopting ADO)

```bash
az login                                                                  # Entra ID OAuth
az extension add --name azure-devops                                      # required extension
az devops configure --defaults organization=https://dev.azure.com/<org> project=<project>
```

Then in any project, set `.claude/tracker.json`:

```json
{
  "tracker": "azure-devops",
  "azure-devops": {
    "organization": "https://dev.azure.com/your-org",
    "project": "your-project",
    "state_transitions": {
      "research-in-progress": { "state": "Active" },
      "in-progress": { "state": "Active" },
      "pr-submitted": { "state": "Resolved" },
      "pr-merged": { "state": "Closed" }
    }
  }
}
```

The `state_transitions` block is optional. Without it, Tags are added/removed only; with it, the typed `System.State` is also transitioned at the specified neutral states.

## Test Plan

### Verified locally

- [x] `bash -n .claude/scripts/tracker.sh` - syntax clean.
- [x] `bash .claude/scripts/tracker.sh backend` - prints `github` (default).
- [x] `TRACKER_BACKEND=azure-devops bash .claude/scripts/tracker.sh backend` - prints `azure-devops`.
- [x] `TRACKER_BACKEND=azure-devops bash .claude/scripts/tracker.sh view 1` - dispatches to `azdo_view` and reaches the `az` CLI (which errors cleanly with "--organization must be specified" on an unconfigured box).
- [x] `TRACKER_BACKEND=none bash .claude/scripts/tracker.sh view 1` - returns `{}` (none backend unchanged).
- [x] Tag-helper unit tests (6/6 pass):
  - `azdo_tags_remove "research-in-progress; planning" "planning"` -> `research-in-progress`
  - `azdo_tags_remove "planning; research-in-progress" "planning"` -> `research-in-progress`
  - `azdo_tags_remove "planning" "planning"` -> `(empty)`
  - `azdo_tags_add "" "X"` -> `X`
  - `azdo_tags_add "Y; Z" "X"` -> `Y; Z; X`
  - `azdo_tags_add "Y; Z" "Y"` -> `Y; Z` (dedup)

### To verify against a real ADO setup (after merge)

- [ ] Set `.claude/tracker.json` with your org / project. Run `tracker view <work-item-id>` and confirm it returns the work item JSON.
- [ ] `tracker set-state <id> research-in-progress` - verify the tag appears on the work item in the ADO UI. With `state_transitions` configured, verify System.State transitions too.
- [ ] `tracker set-state <id> research-complete research-in-progress` - verify the old tag is removed and the new one added.
- [ ] `tracker comment <id> "hello"` - verify a discussion comment appears.
- [ ] On a branch with a PR open: `tracker pr-current` returns the PR JSON.
- [ ] `tracker pr-view <pr-id>`, `tracker pr-diff <pr-id>`, `tracker pr-list-open` - all return sensible output.
- [ ] `tracker pr-comment <pr-id> "test"` - confirm a thread appears on the PR.
- [ ] `tracker pr-decision <pr-id>` - with at least one approver, returns `{"reviewDecision":"APPROVED"}`.
- [ ] (End-to-end) Run `/research-requirements <work-item-url>` against a real ADO work item and confirm the state transitions through the workflow.

## Checklist

- [x] Self-review completed
- [x] Tests pass locally (`bash -n` + dispatch + tag helpers; full ADO verification is post-merge against the user's environment)
- [x] Documentation updated ([docs/tracker-portability.md](docs/tracker-portability.md))

## Context

- The contract / dispatcher / config / docs scaffolding was established in PR 1 (#35); this PR is purely the ADO-side wiring.
- A few GitHub-Action-specific bits intentionally remain in skill bodies (the `@claude` review filter in `/handle-pr-feedback`, the GitHub permalink URL shape in `/research-codebase`) - they have no clean ADO equivalent and the docs flag them.
- Follows #35 (tracker abstraction PR 1), #36 (claude-code-flow → flow rename), #37 (plugin scaffolding).
- Next natural step: shake the ADO backend out against your real Foundry / DevOps org and tighten anything the docs miss.
