### PR TITLE
Fix stale tracker.sh comment: azure-devops backend is wired, not a stub

### DIFF
--- a/.claude/scripts/tracker.sh
+++ b/.claude/scripts/tracker.sh
@@ -2,9 +2,9 @@
 # Tracker adapter: abstracts issue / work-item and PR operations across trackers.
 #
 # Workflow skills call this script instead of using a specific tracker's CLI
-# directly. Today the only fully wired backend is `github` (which dispatches
-# to `gh`). The `azure-devops` backend is a stub returning a clear error;
-# the `none` backend is a tracker-less mode for projects without an issue tracker.
+# directly. Two backends are fully wired: `github` (dispatches to `gh`) and
+# `azure-devops` (dispatches to `az` with the azure-devops extension). The
+# `none` backend is a tracker-less mode for projects without an issue tracker.
 #
 # Usage:  bash .claude/scripts/tracker.sh <subcommand> <args...>
 #


### PR DESCRIPTION
## What

Fix a stale comment in the tracker adapter header. It still described the `azure-devops` backend as "a stub returning a clear error", but PR #38 wired it.

## Why

The header misleads anyone reading the script: both `github` and `azure-devops` are now fully wired backends. Only the comment was wrong.

## Change

- [`.claude/scripts/tracker.sh:5-7`](.claude/scripts/tracker.sh#L5-L7): describe both `github` (via `gh`) and `azure-devops` (via `az` plus the azure-devops extension) as fully wired.

Comment-only, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)