### PR TITLE
Fix plugin manifest: skills path must start with ./

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,5 +19,5 @@
     "agent-skills",
     "agents-md"
   ],
-  "skills": ".claude/skills/"
+  "skills": "./.claude/skills/"
 }


### PR DESCRIPTION
## Problem

`/plugin install flow@flow` fails at the manifest-validation step:

```
invalid manifest file ... Validation errors: skills: Invalid input
```

## Cause

The Claude Code plugin manifest schema requires every path field to **start with `./`** and resolve **inside the plugin root** ([plugins reference](https://code.claude.com/docs/en/plugins-reference)). The `skills` field was `".claude/skills/"` with no `./` prefix, so the validator rejected it before any component was discovered.

## Fix

- [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json): `".claude/skills/"` → `"./.claude/skills/"`.

`.claude/skills/` is a real directory inside the plugin root (sibling of `.claude-plugin/`), so only the prefix was wrong. After this, the 31 skills under `.claude/skills/` load on install. Agents already auto-discover from the plugin-root `agents/` directory (PR #39), so no `agents` field is needed.

## Verification

- `jq` parses the manifest.
- Manual reinstall after merge: `/plugin marketplace update flow` then `/plugin install flow@flow` should succeed and surface the `/flow:*` skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)