### PR TITLE
Fix tracker.sh path in skills so it resolves when Flow is an installed plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -157,8 +157,8 @@ Then wait for the user's input.
 
 1. **Fetch the work item if provided**:
    - If a tracker URL or work-item id is provided:
-     - Fetch it: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
-     - Transition state: `bash .claude/scripts/tracker.sh set-state <id> planning-in-progress research-complete`
+     - Fetch it: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
+     - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> planning-in-progress research-complete`
    - Read the content fully before proceeding
    - Note any linked work items, PRs, or references mentioned
 
@@ -440,7 +440,7 @@ After structure approval:
 3. **Continue refining** until the user is satisfied
 
 4. **Transition the work-item state** (if applicable):
-   - Once the plan is finalized and approved: `bash .claude/scripts/tracker.sh set-state <id> ready-for-dev planning-in-progress`
+   - Once the plan is finalized and approved: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> ready-for-dev planning-in-progress`
 
 ## Important Guidelines
 
@@ -586,7 +586,7 @@ tasks = [
 User: /create-plan #1
 Assistant: Let me fetch that work item and understand what we're building...
 
-[Fetches with `bash .claude/scripts/tracker.sh view 1`]
+[Fetches with `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view 1`]
 
 Based on the work item, I understand we need to create a /research-requirements skill for greenfield projects. Let me research the codebase to understand the existing patterns...
 

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -16,8 +16,8 @@ You are tasked with generating a comprehensive pull request description followin
    - Read the template carefully to understand all sections and requirements
 
 2. **Identify the PR to describe:**
-   - Check if the current branch has an associated PR: `bash .claude/scripts/tracker.sh pr-current --json url,number,title,state 2>/dev/null`
-   - If no PR exists for the current branch, or if on main/master, list open PRs: `bash .claude/scripts/tracker.sh pr-list-open`
+   - Check if the current branch has an associated PR: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-current --json url,number,title,state 2>/dev/null`
+   - If no PR exists for the current branch, or if on main/master, list open PRs: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-list-open`
    - Ask the user which PR they want to describe
 
 3. **Check for existing description:**
@@ -26,11 +26,11 @@ You are tasked with generating a comprehensive pull request description followin
    - Consider what has changed since the last description was written
 
 4. **Gather comprehensive PR information:**
-   - Get the full PR diff: `bash .claude/scripts/tracker.sh pr-diff {number}`
+   - Get the full PR diff: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-diff {number}`
    - On GitHub: if you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
-   - Get commit history: `bash .claude/scripts/tracker.sh pr-view {number} --json commits`
-   - Review the base branch: `bash .claude/scripts/tracker.sh pr-view {number} --json baseRefName`
-   - Get PR metadata: `bash .claude/scripts/tracker.sh pr-view {number} --json url,title,number,state`
+   - Get commit history: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json commits`
+   - Review the base branch: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json baseRefName`
+   - Get PR metadata: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json url,title,number,state`
 
 5. **Analyze the changes thoroughly:** (ultrathink about the code changes, their architectural implications, and potential impacts)
    - Read through the entire diff carefully
@@ -61,13 +61,13 @@ You are tasked with generating a comprehensive pull request description followin
    - Show the user the generated description
 
 9. **Update the PR:**
-   - Update the PR description directly: `bash .claude/scripts/tracker.sh pr-edit-body {number} flow/prs/{number}_description.md`
+   - Update the PR description directly: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-edit-body {number} flow/prs/{number}_description.md`
    - Confirm the update was successful
    - If any verification steps remain unchecked, remind the user to complete them before merging
 
 10. **Transition linked work-item states** (if PR is linked to issues / work items):
-    - Get linked work-item ids: `bash .claude/scripts/tracker.sh pr-closing-issues {number}`
-    - For each linked work item: `bash .claude/scripts/tracker.sh set-state <id> pr-submitted in-progress`
+    - Get linked work-item ids: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-closing-issues {number}`
+    - For each linked work item: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> pr-submitted in-progress`
 
 ## Important notes:
 - This command works across different repositories - always read the local template

--- a/.claude/skills/handle-pr-feedback/SKILL.md
+++ b/.claude/skills/handle-pr-feedback/SKILL.md
@@ -25,7 +25,7 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 - Use the provided PR number
 
 **If no PR number provided:**
-- Auto-detect from current branch: `bash .claude/scripts/tracker.sh pr-current --json number,title,headRefName 2>/dev/null`
+- Auto-detect from current branch: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-current --json number,title,headRefName 2>/dev/null`
 - If multiple PRs or unclear, ask user which PR to handle
 
 ### 2. Fetch PR Review Feedback
@@ -33,10 +33,10 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 ```bash
 # Get PR reviews + comments. The author.login filter for "claude-code[bot]" / "@claude"
 # is GitHub-Actions-specific; substitute for other trackers / review systems.
-bash .claude/scripts/tracker.sh pr-view <pr-id> --json reviews,comments | jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json reviews,comments | jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
 
 # Also get inline review comments
-bash .claude/scripts/tracker.sh pr-review-comments <pr-id>
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-review-comments <pr-id>
 ```
 
 **Parse the feedback:**
@@ -46,7 +46,7 @@ bash .claude/scripts/tracker.sh pr-review-comments <pr-id>
 - Extract specific file locations and suggested fixes
 
 **If no feedback found:**
-- Check if review is still pending: `bash .claude/scripts/tracker.sh pr-decision <pr-id>`
+- Check if review is still pending: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-decision <pr-id>`
 - If APPROVED: notify user "PR already approved, no changes needed"
 - If CHANGES_REQUESTED but no comments: ask user to specify what to fix
 - If pending: notify user to wait for review to complete
@@ -56,16 +56,16 @@ bash .claude/scripts/tracker.sh pr-review-comments <pr-id>
 ```bash
 # Look for plan file related to this PR
 # Strategy 1: Check PR description for plan reference
-bash .claude/scripts/tracker.sh pr-view <pr-id> --json body | grep -o "flow/plans/[^)]*"
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json body | grep -o "flow/plans/[^)]*"
 
 # Strategy 2: Get work-item id from PR title/body
-bash .claude/scripts/tracker.sh pr-view <pr-id> --json title,body | grep -o "#[0-9]*" | head -1
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json title,body | grep -o "#[0-9]*" | head -1
 
 # Then find plan (gh-<n> filename prefix is a stable convention regardless of tracker):
 ls flow/plans/*-gh-<work-item-id>-*.md 2>/dev/null
 
 # Strategy 3: Check commits for plan references
-bash .claude/scripts/tracker.sh pr-view <pr-id> --json commits | grep -o "flow/plans/[^)]*"
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json commits | grep -o "flow/plans/[^)]*"
 ```
 
 **If plan not found:**
@@ -191,7 +191,7 @@ git push
 ```bash
 # Comment on the PR to request re-review (the '@claude' tag triggers the
 # Claude Code GitHub Action; substitute the equivalent for other systems).
-bash .claude/scripts/tracker.sh pr-comment <pr-id> "@claude I've addressed your feedback in the latest commit. Please re-review:
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-comment <pr-id> "@claude I've addressed your feedback in the latest commit. Please re-review:
 
 Changes made:
 - <change 1>
@@ -204,7 +204,7 @@ All tests passing ✅"
 
 ```bash
 # Get linked work-item ids
-bash .claude/scripts/tracker.sh pr-closing-issues <pr-id>
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-closing-issues <pr-id>
 
 # Keep work item in 'in-progress' (already there, no change needed)
 ```

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -15,7 +15,7 @@ When given a plan path:
 - Read the plan completely and check for any existing checkmarks (- [x])
 - Read the original ticket and all files mentioned in the plan
 - **Read files fully** - never use limit/offset parameters, you need complete context
-- **Transition the work-item state** (if an issue / work item is referenced in the plan): `bash .claude/scripts/tracker.sh set-state <id> in-progress ready-for-dev`
+- **Transition the work-item state** (if an issue / work item is referenced in the plan): `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> in-progress ready-for-dev`
 - Think deeply about how the pieces fit together
 - Create a todo list to track your progress
 - Start implementing if you understand what needs to be done

--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -32,8 +32,8 @@ Then wait for the user's research query.
 
 1. **Read any directly mentioned files first:**
    - If the research query is a tracker URL or work-item id:
-     - Fetch work-item content: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
-     - Transition state: `bash .claude/scripts/tracker.sh set-state <id> research-in-progress`
+     - Fetch work-item content: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
+     - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-in-progress`
    - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
    - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
    - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
@@ -160,12 +160,12 @@ Then wait for the user's research query.
 
 7. **Add repository permalinks (if applicable; GitHub URL shape shown - substitute for other hosts):**
    - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
-   - For GitHub, get repo info: `bash .claude/scripts/tracker.sh repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - For GitHub, get repo info: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
    - For other hosts, substitute the appropriate URL shape (e.g. Azure DevOps: `https://dev.azure.com/{org}/{project}/_git/{repo}?path=/{file}&version=GC{commit}&line={line}`)
    - Replace local file references with permalinks in the document
 
 8. **Present findings:**
-   - Transition the work-item state (if applicable): `bash .claude/scripts/tracker.sh set-state <id> research-complete research-in-progress`
+   - Transition the work-item state (if applicable): `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-complete research-in-progress`
    - Present a concise summary of findings to the user
    - Include key file references for easy navigation
    - Ask if they have follow-up questions or need clarification

--- a/.claude/skills/research-requirements/SKILL.md
+++ b/.claude/skills/research-requirements/SKILL.md
@@ -40,8 +40,8 @@ Then wait for user input.
 ### Step 1: Parse Input Source
 
 - If a tracker URL or work-item id was provided:
-  - Fetch the work-item content: `bash .claude/scripts/tracker.sh view <id> --json title,body,state,comments`
-  - Transition state: `bash .claude/scripts/tracker.sh set-state <id> research-in-progress`
+  - Fetch the work-item content: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
+  - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-in-progress`
 - If plain text: use as-is
 - **CRITICAL**: Read/fetch input FULLY before spawning sub-tasks
 
@@ -183,7 +183,7 @@ status: complete
 After writing the document:
 
 1. **Transition the work-item state** (if applicable):
-   - `bash .claude/scripts/tracker.sh set-state <id> research-complete research-in-progress`
+   - `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-complete research-in-progress`
 
 2. **Present summary to user**:
 ```

--- a/.claude/skills/validate-plan/SKILL.md
+++ b/.claude/skills/validate-plan/SKILL.md
@@ -136,7 +136,7 @@ Based on validation results:
 
 **If validation fails** (automated checks fail, critical issues found):
 ```bash
-bash .claude/scripts/tracker.sh set-state <id> validation-failed in-progress
+bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> validation-failed in-progress
 ```
 
 **If validation passes** (all automated checks pass, ready for PR):


### PR DESCRIPTION
## Problem

All 31 tracker calls across the 7 workflow skills were hardcoded as `bash .claude/scripts/tracker.sh` - a **repo-relative** path. That only works when Flow is the cloned project. When Flow is installed as a **plugin** into another repo, the adapter lives in the plugin's install dir, not the consuming repo, so every call hit "no such file" and the tracker state transitions (`research-in-progress` → `research-complete`, etc.) **silently no-opped**. Surfaced by the brownfield install test against `corticalstack/AI-Landingzone`.

## Fix

Reference the adapter via the **documented skill substitution** `${CLAUDE_SKILL_DIR}` (per the [Skills docs](https://code.claude.com/docs/en/skills) - this is the supported variable for skills; `CLAUDE_PLUGIN_ROOT` is hooks-only). Skills live at `<root>/.claude/skills/<name>/` and the adapter at `<root>/.claude/scripts/tracker.sh`, so:

```bash
bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" ...
```

`${CLAUDE_SKILL_DIR}` is a string substitution (not an env var), so it's reliable inside Bash commands, and the skill-to-script relative layout is identical in **both** modes:
- **Plugin:** resolves to the plugin's bundled `.claude/scripts/tracker.sh`.
- **Cloned template:** resolves to the repo's own `.claude/scripts/tracker.sh`.

Changed all 31 call-sites across `create-plan`, `describe-pr`, `handle-pr-feedback`, `implement-plan`, `research-codebase`, `research-requirements`, `validate-plan`. Docs that *describe* the repo path (AGENTS.md, README, docs/tracker-portability.md) are left as-is since they're accurate for the repo. Plugin bumped 0.1.1 → 0.1.2.

## Why not have `/flow:init` copy the adapter in?

That would work too, but it requires running `init` and creates a per-repo copy that drifts from the plugin. Referencing the plugin's own adapter keeps a single source of truth and works without `init`.

## Verification

- `grep` confirms 0 remaining `bash .claude/scripts/tracker.sh` and 31 of the new form.
- Full verification requires merge → `claude plugin update flow@flow` → run a tracker-touching skill (e.g. `/flow:research-codebase <issue>`) in a brownfield repo and confirm the state label actually flips. That's the brownfield test's job.

## Assumption

Relies on `${CLAUDE_SKILL_DIR}` resolving to `<...>/.claude/skills/<name>` with a sibling `.claude/scripts/` (true because the plugin ships the repo structure). If Claude Code ever flattens skill staging, the `../../scripts/` hop would need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)