### PR TITLE
Mention llm-as-judge in descriptions; add marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "flow",
+  "description": "Flow: a cross-tool agentic-coding workflow toolkit (research, plan, implement, validate) with a tracker abstraction.",
   "owner": {
     "name": "corticalstack"
   },
@@ -7,7 +8,7 @@
     {
       "name": "flow",
       "source": ".",
-      "description": "A cross-tool agentic-coding workflow toolkit (12 workflow skills + optional cross-vendor review + tracker abstraction)."
+      "description": "A cross-tool agentic-coding workflow toolkit (12 workflow skills + optional cross-vendor review + LLM-as-judge + tracker abstraction)."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "flow",
   "displayName": "Flow",
   "version": "0.1.3",
-  "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
+  "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"
   },


### PR DESCRIPTION
## What

Two small metadata fixes following the skills cleanup:

1. **`llm-as-judge` now in the descriptions.** Both `plugin.json` `description` and the marketplace per-plugin description previously listed only the 12 workflow skills + cross-vendor review; they now also note the LLM-as-judge evaluation skill that was kept.
2. **Top-level `marketplace.json` description added.** This clears the benign `claude plugin validate` warning ("No marketplace description provided"), matching what the new corticalstack/{writing,thinking,engineering} repos already have.

## Verification

- Both files are valid JSON.
- `claude plugin validate .` now reports **"Validation passed"** (previously "passed with warnings").

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)