### PR TITLE
Bump plugin to 0.1.4 to apply the description update

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"


### PR DESCRIPTION
## Why

PR #45 updated the descriptions (added `llm-as-judge`; added the top-level marketplace description) but kept the version at 0.1.3. `claude plugin update flow@flow` skips same-version updates, so installed plugins never picked up the new description.

## Change

- `.claude-plugin/plugin.json`: `version` 0.1.3 → 0.1.4. One line, no other changes.

After merge: `claude plugin marketplace update flow` + `claude plugin update flow@flow` will cleanly apply the refreshed description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)