### PR TITLE
research-codebase: emit navigable markdown links for code references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"

--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -132,7 +132,7 @@ Then wait for the user's research query.
      ## Detailed Findings
 
      ### [Component/Area 1]
-     - Description of what exists ([file.ext:line](link))
+     - Description of what exists ([file.ext:line](https://github.com/{owner}/{repo}/blob/{commit}/file.ext#L{line}))
      - How it connects to other components
      - Current implementation details (without evaluation)
 
@@ -140,8 +140,8 @@ Then wait for the user's research query.
      ...
 
      ## Code References
-     - `path/to/file.py:123` - Description of what's there
-     - `another/file.ts:45-67` - Description of the code block
+     - [path/to/file.py:123](https://github.com/{owner}/{repo}/blob/{commit}/path/to/file.py#L123) - Description of what's there
+     - [another/file.ts:45-67](https://github.com/{owner}/{repo}/blob/{commit}/another/file.ts#L45-L67) - Description of the code block
 
      ## Architecture Documentation
      [Current patterns, conventions, and design implementations found in the codebase]
@@ -162,7 +162,8 @@ Then wait for the user's research query.
    - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
    - For GitHub, get repo info: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
    - For other hosts, substitute the appropriate URL shape (e.g. Azure DevOps: `https://dev.azure.com/{org}/{project}/_git/{repo}?path=/{file}&version=GC{commit}&line={line}`)
-   - Replace local file references with permalinks in the document
+   - **Every `path:line` reference in the document body MUST be its own clickable markdown link** - `[path:line](permalink)`, with ranges as `#L{start}-L{end}` - across Detailed Findings, the Code References section, and any tables. Do NOT leave bare `path:line` text, and do NOT just state a single "permalink base" at the top and leave the references plain; render each reference individually.
+   - Use the full commit permalink when the commit is pushed; if the branch/commit is not pushed, fall back to a repo-relative link `[path:line](path)` so every reference stays navigable.
 
 8. **Present findings:**
    - Transition the work-item state (if applicable): `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-complete research-in-progress`


### PR DESCRIPTION
## Problem

`research-codebase` output put a single **permalink base** line at the top and left every reference as bare `path:line` text (e.g. `infra/terraform/main.tf:128-320`). Those aren't clickable, and it violates the project's own convention ("use navigable links for file references, not bare backticks").

Root cause is in the **orchestrator skill**, not `codebase-locator`: the locator/analyzer sub-agents return `path:line` findings and have no git commit/remote context, so building permalinks is the orchestrator's synthesis job. The skill already said "replace file references with permalinks," but:
- the document template's **Code References** section showed bare backticks (`` `path/to/file.py:123` ``), and
- step 7's instruction was too soft, so the model emitted a base URL + plain refs.

## Fix (`research-codebase/SKILL.md`)

- **Code References template** → markdown links: `[path/to/file.py:123](https://github.com/{owner}/{repo}/blob/{commit}/path/to/file.py#L123)`.
- **Detailed Findings template** → shows the concrete permalink shape inline.
- **Step 7** → now mandates that *every* `path:line` reference is its own clickable link (across Detailed Findings, Code References, and tables), explicitly forbids the "single permalink base + bare refs" shortcut, and adds a repo-relative fallback (`[path:line](path)`) when the commit isn't pushed.

Bumped 0.1.4 → 0.1.5. Validates cleanly.

## Note

`create-plan`'s References template has the same bare-backtick pattern (`Similar implementation: [file:line]`). Out of scope here, but happy to apply the same fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)