### PR TITLE
create-plan: emit navigable markdown links for code references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -314,7 +314,7 @@ After structure approval:
 [A Specification of the desired end state after this plan is complete, and how to verify it]
 
 ### Key Discoveries:
-- [Important finding with file:line reference]
+- [Important finding as a navigable link, e.g. [main.tf:42](https://github.com/{owner}/{repo}/blob/{commit}/path/to/main.tf#L42)]
 - [Pattern to follow]
 - [Constraint to work within]
 
@@ -413,9 +413,11 @@ After structure approval:
 ## References
 
 - Tracker work item: https://github.com/[owner]/[repo]/issues/[number] (GitHub example - substitute the URL shape for your tracker)
-- Related research: `flow/research/[relevant].md`
-- Similar implementation: `[file:line]`
+- Related research: [flow/research/[relevant].md](flow/research/[relevant].md)
+- Similar implementation: [path/to/file:line](https://github.com/{owner}/{repo}/blob/{commit}/path/to/file#L{line})
 ````
+
+3. **Render every code reference as a navigable markdown link.** Do not write bare `file:line` text. Gather the repo + commit once (`git rev-parse HEAD`, `git branch --show-current`, `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" repo-info`) and form `[path:line](https://github.com/{owner}/{repo}/blob/{commit}/{path}#L{line})` (ranges as `#L{start}-L{end}`) for every reference across Current State Analysis, Key Discoveries, the implementation phases, and References. If the commit is not pushed, fall back to a repo-relative link `[path:line](path)` so every reference stays navigable. For non-GitHub trackers, substitute the host's blob-URL shape.
 
 ### Step 5: Review
 


### PR DESCRIPTION
## Problem

`create-plan` output lists code locations as bare `file:line` text (e.g. `variables.tf:728`, `main.tf:369-419`, `locals.tf:106`) - not clickable, same gap just fixed in `research-codebase` (#47), and against the project's navigable-link convention.

Unlike `research-codebase`, `create-plan` had **no** permalink/linking step at all, and its template seeded the bare style: Key Discoveries used `[Important finding with file:line reference]` and References used `` `[file:line]` ``.

## Fix (`create-plan/SKILL.md`)

- **Key Discoveries** template → shows a navigable link example.
- **References** template → `Related research` and `Similar implementation` become markdown links.
- **New Step 4 instruction** → render every `file:line` reference as a clickable link across Current State Analysis, Key Discoveries, the implementation phases, and References; gather repo+commit (`git rev-parse HEAD` + `tracker.sh repo-info`) for the permalink, with a repo-relative fallback when the commit isn't pushed.

Bumped 0.1.5 → 0.1.6. Validates cleanly. This is the follow-up flagged in #47; the workflow's two reference-producing skills now both emit navigable links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)