### PR TITLE
Skills call tracker via PATH (plugin-first), closing the doc-vs-code gap

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A cross-tool agentic-coding workflow toolkit: 12 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -157,8 +157,8 @@ Then wait for the user's input.
 
 1. **Fetch the work item if provided**:
    - If a tracker URL or work-item id is provided:
-     - Fetch it: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
-     - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> planning-in-progress research-complete`
+     - Fetch it: `tracker view <id> --json title,body,state,comments`
+     - Transition state: `tracker set-state <id> planning-in-progress research-complete`
    - Read the content fully before proceeding
    - Note any linked work items, PRs, or references mentioned
 
@@ -417,7 +417,7 @@ After structure approval:
 - Similar implementation: [path/to/file:line](https://github.com/{owner}/{repo}/blob/{commit}/path/to/file#L{line})
 ````
 
-3. **Render every code reference as a navigable markdown link.** Do not write bare `file:line` text. Gather the repo + commit once (`git rev-parse HEAD`, `git branch --show-current`, `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" repo-info`) and form `[path:line](https://github.com/{owner}/{repo}/blob/{commit}/{path}#L{line})` (ranges as `#L{start}-L{end}`) for every reference across Current State Analysis, Key Discoveries, the implementation phases, and References. If the commit is not pushed, fall back to a repo-relative link `[path:line](path)` so every reference stays navigable. For non-GitHub trackers, substitute the host's blob-URL shape.
+3. **Render every code reference as a navigable markdown link.** Do not write bare `file:line` text. Gather the repo + commit once (`git rev-parse HEAD`, `git branch --show-current`, `tracker repo-info`) and form `[path:line](https://github.com/{owner}/{repo}/blob/{commit}/{path}#L{line})` (ranges as `#L{start}-L{end}`) for every reference across Current State Analysis, Key Discoveries, the implementation phases, and References. If the commit is not pushed, fall back to a repo-relative link `[path:line](path)` so every reference stays navigable. For non-GitHub trackers, substitute the host's blob-URL shape.
 
 ### Step 5: Review
 
@@ -442,7 +442,7 @@ After structure approval:
 3. **Continue refining** until the user is satisfied
 
 4. **Transition the work-item state** (if applicable):
-   - Once the plan is finalized and approved: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> ready-for-dev planning-in-progress`
+   - Once the plan is finalized and approved: `tracker set-state <id> ready-for-dev planning-in-progress`
 
 ## Important Guidelines
 
@@ -588,7 +588,7 @@ tasks = [
 User: /create-plan #1
 Assistant: Let me fetch that work item and understand what we're building...
 
-[Fetches with `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view 1`]
+[Fetches with `tracker view 1`]
 
 Based on the work item, I understand we need to create a /research-requirements skill for greenfield projects. Let me research the codebase to understand the existing patterns...
 

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -16,8 +16,8 @@ You are tasked with generating a comprehensive pull request description followin
    - Read the template carefully to understand all sections and requirements
 
 2. **Identify the PR to describe:**
-   - Check if the current branch has an associated PR: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-current --json url,number,title,state 2>/dev/null`
-   - If no PR exists for the current branch, or if on main/master, list open PRs: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-list-open`
+   - Check if the current branch has an associated PR: `tracker pr-current --json url,number,title,state 2>/dev/null`
+   - If no PR exists for the current branch, or if on main/master, list open PRs: `tracker pr-list-open`
    - Ask the user which PR they want to describe
 
 3. **Check for existing description:**
@@ -26,11 +26,11 @@ You are tasked with generating a comprehensive pull request description followin
    - Consider what has changed since the last description was written
 
 4. **Gather comprehensive PR information:**
-   - Get the full PR diff: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-diff {number}`
+   - Get the full PR diff: `tracker pr-diff {number}`
    - On GitHub: if you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
-   - Get commit history: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json commits`
-   - Review the base branch: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json baseRefName`
-   - Get PR metadata: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view {number} --json url,title,number,state`
+   - Get commit history: `tracker pr-view {number} --json commits`
+   - Review the base branch: `tracker pr-view {number} --json baseRefName`
+   - Get PR metadata: `tracker pr-view {number} --json url,title,number,state`
 
 5. **Analyze the changes thoroughly:** (ultrathink about the code changes, their architectural implications, and potential impacts)
    - Read through the entire diff carefully
@@ -61,13 +61,13 @@ You are tasked with generating a comprehensive pull request description followin
    - Show the user the generated description
 
 9. **Update the PR:**
-   - Update the PR description directly: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-edit-body {number} flow/prs/{number}_description.md`
+   - Update the PR description directly: `tracker pr-edit-body {number} flow/prs/{number}_description.md`
    - Confirm the update was successful
    - If any verification steps remain unchecked, remind the user to complete them before merging
 
 10. **Transition linked work-item states** (if PR is linked to issues / work items):
-    - Get linked work-item ids: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-closing-issues {number}`
-    - For each linked work item: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> pr-submitted in-progress`
+    - Get linked work-item ids: `tracker pr-closing-issues {number}`
+    - For each linked work item: `tracker set-state <id> pr-submitted in-progress`
 
 ## Important notes:
 - This command works across different repositories - always read the local template

--- a/.claude/skills/handle-pr-feedback/SKILL.md
+++ b/.claude/skills/handle-pr-feedback/SKILL.md
@@ -25,7 +25,7 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 - Use the provided PR number
 
 **If no PR number provided:**
-- Auto-detect from current branch: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-current --json number,title,headRefName 2>/dev/null`
+- Auto-detect from current branch: `tracker pr-current --json number,title,headRefName 2>/dev/null`
 - If multiple PRs or unclear, ask user which PR to handle
 
 ### 2. Fetch PR Review Feedback
@@ -33,10 +33,10 @@ You are tasked with handling feedback from @claude's PR review. This command fet
 ```bash
 # Get PR reviews + comments. The author.login filter for "claude-code[bot]" / "@claude"
 # is GitHub-Actions-specific; substitute for other trackers / review systems.
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json reviews,comments | jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
+tracker pr-view <pr-id> --json reviews,comments | jq '.reviews[] | select(.author.login == "claude-code[bot]" or .body | contains("@claude"))'
 
 # Also get inline review comments
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-review-comments <pr-id>
+tracker pr-review-comments <pr-id>
 ```
 
 **Parse the feedback:**
@@ -46,7 +46,7 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-review-comments <pr-id>
 - Extract specific file locations and suggested fixes
 
 **If no feedback found:**
-- Check if review is still pending: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-decision <pr-id>`
+- Check if review is still pending: `tracker pr-decision <pr-id>`
 - If APPROVED: notify user "PR already approved, no changes needed"
 - If CHANGES_REQUESTED but no comments: ask user to specify what to fix
 - If pending: notify user to wait for review to complete
@@ -56,16 +56,16 @@ bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-review-comments <pr-id>
 ```bash
 # Look for plan file related to this PR
 # Strategy 1: Check PR description for plan reference
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json body | grep -o "flow/plans/[^)]*"
+tracker pr-view <pr-id> --json body | grep -o "flow/plans/[^)]*"
 
 # Strategy 2: Get work-item id from PR title/body
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json title,body | grep -o "#[0-9]*" | head -1
+tracker pr-view <pr-id> --json title,body | grep -o "#[0-9]*" | head -1
 
 # Then find plan (gh-<n> filename prefix is a stable convention regardless of tracker):
 ls flow/plans/*-gh-<work-item-id>-*.md 2>/dev/null
 
 # Strategy 3: Check commits for plan references
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-view <pr-id> --json commits | grep -o "flow/plans/[^)]*"
+tracker pr-view <pr-id> --json commits | grep -o "flow/plans/[^)]*"
 ```
 
 **If plan not found:**
@@ -191,7 +191,7 @@ git push
 ```bash
 # Comment on the PR to request re-review (the '@claude' tag triggers the
 # Claude Code GitHub Action; substitute the equivalent for other systems).
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-comment <pr-id> "@claude I've addressed your feedback in the latest commit. Please re-review:
+tracker pr-comment <pr-id> "@claude I've addressed your feedback in the latest commit. Please re-review:
 
 Changes made:
 - <change 1>
@@ -204,7 +204,7 @@ All tests passing ✅"
 
 ```bash
 # Get linked work-item ids
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" pr-closing-issues <pr-id>
+tracker pr-closing-issues <pr-id>
 
 # Keep work item in 'in-progress' (already there, no change needed)
 ```

--- a/.claude/skills/implement-plan/SKILL.md
+++ b/.claude/skills/implement-plan/SKILL.md
@@ -15,7 +15,7 @@ When given a plan path:
 - Read the plan completely and check for any existing checkmarks (- [x])
 - Read the original ticket and all files mentioned in the plan
 - **Read files fully** - never use limit/offset parameters, you need complete context
-- **Transition the work-item state** (if an issue / work item is referenced in the plan): `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> in-progress ready-for-dev`
+- **Transition the work-item state** (if an issue / work item is referenced in the plan): `tracker set-state <id> in-progress ready-for-dev`
 - Think deeply about how the pieces fit together
 - Create a todo list to track your progress
 - Start implementing if you understand what needs to be done

--- a/.claude/skills/research-codebase/SKILL.md
+++ b/.claude/skills/research-codebase/SKILL.md
@@ -32,8 +32,8 @@ Then wait for the user's research query.
 
 1. **Read any directly mentioned files first:**
    - If the research query is a tracker URL or work-item id:
-     - Fetch work-item content: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
-     - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-in-progress`
+     - Fetch work-item content: `tracker view <id> --json title,body,state,comments`
+     - Transition state: `tracker set-state <id> research-in-progress`
    - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
    - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
    - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
@@ -160,13 +160,13 @@ Then wait for the user's research query.
 
 7. **Add repository permalinks (if applicable; GitHub URL shape shown - substitute for other hosts):**
    - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
-   - For GitHub, get repo info: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - For GitHub, get repo info: `tracker repo-info` and form permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
    - For other hosts, substitute the appropriate URL shape (e.g. Azure DevOps: `https://dev.azure.com/{org}/{project}/_git/{repo}?path=/{file}&version=GC{commit}&line={line}`)
    - **Every `path:line` reference in the document body MUST be its own clickable markdown link** - `[path:line](permalink)`, with ranges as `#L{start}-L{end}` - across Detailed Findings, the Code References section, and any tables. Do NOT leave bare `path:line` text, and do NOT just state a single "permalink base" at the top and leave the references plain; render each reference individually.
    - Use the full commit permalink when the commit is pushed; if the branch/commit is not pushed, fall back to a repo-relative link `[path:line](path)` so every reference stays navigable.
 
 8. **Present findings:**
-   - Transition the work-item state (if applicable): `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-complete research-in-progress`
+   - Transition the work-item state (if applicable): `tracker set-state <id> research-complete research-in-progress`
    - Present a concise summary of findings to the user
    - Include key file references for easy navigation
    - Ask if they have follow-up questions or need clarification

--- a/.claude/skills/research-requirements/SKILL.md
+++ b/.claude/skills/research-requirements/SKILL.md
@@ -40,8 +40,8 @@ Then wait for user input.
 ### Step 1: Parse Input Source
 
 - If a tracker URL or work-item id was provided:
-  - Fetch the work-item content: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" view <id> --json title,body,state,comments`
-  - Transition state: `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-in-progress`
+  - Fetch the work-item content: `tracker view <id> --json title,body,state,comments`
+  - Transition state: `tracker set-state <id> research-in-progress`
 - If plain text: use as-is
 - **CRITICAL**: Read/fetch input FULLY before spawning sub-tasks
 
@@ -183,7 +183,7 @@ status: complete
 After writing the document:
 
 1. **Transition the work-item state** (if applicable):
-   - `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> research-complete research-in-progress`
+   - `tracker set-state <id> research-complete research-in-progress`
 
 2. **Present summary to user**:
 ```

--- a/.claude/skills/validate-plan/SKILL.md
+++ b/.claude/skills/validate-plan/SKILL.md
@@ -136,7 +136,7 @@ Based on validation results:
 
 **If validation fails** (automated checks fail, critical issues found):
 ```bash
-bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh" set-state <id> validation-failed in-progress
+tracker set-state <id> validation-failed in-progress
 ```
 
 **If validation passes** (all automated checks pass, ready for PR):

--- a/docs/tracker-portability.md
+++ b/docs/tracker-portability.md
@@ -1,12 +1,12 @@
 # Tracker portability
 
-The workflow skills (`/research-requirements`, `/create-plan`, `/implement-plan`, `/validate-plan`, `/describe-pr`, `/handle-pr-feedback`, etc.) are designed to drive a project from "issue / work item" through "merged PR / merge request", updating tracker state at each stage. Different teams use different trackers (GitHub Issues, Azure DevOps work items, GitLab issues, Jira, or nothing at all), so the skills do not call any tracker's CLI directly. They call a thin adapter at [.claude/scripts/tracker.sh](../.claude/scripts/tracker.sh), which dispatches to whichever backend you've configured.
+The workflow skills (`/research-requirements`, `/create-plan`, `/implement-plan`, `/validate-plan`, `/describe-pr`, `/handle-pr-feedback`, etc.) are designed to drive a project from "issue / work item" through "merged PR / merge request", updating tracker state at each stage. Different teams use different trackers (GitHub Issues, Azure DevOps work items, GitLab issues, Jira, or nothing at all), so the skills do not call any tracker's CLI directly. They call `tracker` - a thin wrapper the plugin puts on the Bash tool's PATH - which dispatches through the adapter at [.claude/scripts/tracker.sh](../.claude/scripts/tracker.sh) to whichever backend you've configured.
 
 This file explains the contract, the supported backends, the neutral workflow-state vocabulary, and how to configure a project.
 
 ## The contract
 
-The adapter exposes a small set of subcommands - the contract every backend must satisfy. Skills call them as `bash .claude/scripts/tracker.sh <subcommand> <args>`.
+The adapter exposes a small set of subcommands - the contract every backend must satisfy. Skills call them as `tracker <subcommand> <args>` - the plugin adds `bin/tracker` (a thin wrapper around the adapter) to the Bash tool's PATH.
 
 ### Issue / work-item subcommands
 
@@ -106,7 +106,7 @@ Skills work without a tracker. Mutating calls are no-ops (logged); query calls r
 3. Override per-invocation via env var if you want a one-off:
 
    ```bash
-   TRACKER_BACKEND=none bash .claude/scripts/tracker.sh view 1
+   TRACKER_BACKEND=none tracker view 1
    ```
 
 ## What is NOT in scope here


### PR DESCRIPTION
## Why

Going **plugin-first** (template-clone usage retired in a follow-up). Claude Code adds an enabled plugin's `bin/` to the Bash tool's PATH ([plugins docs](https://code.claude.com/docs/en/plugins) - verified empirically: `which tracker` → `…/plugins/cache/flow/flow/0.1.6/bin/tracker`, `tracker backend` → `github`). So skills should call the documented `bin/tracker` wrapper by bare name.

This also closes a **doc-vs-code gap**: `docs/tracker-portability.md` and `bin/tracker` already described the `tracker <subcommand>` call form, but the skills actually hardcoded `bash "${CLAUDE_SKILL_DIR}/../../scripts/tracker.sh"` - leaving `bin/tracker` orphaned.

## Change

- All **32** tracker call-sites across the 7 tracker-using skills (`research-codebase`, `research-requirements`, `create-plan`, `implement-plan`, `validate-plan`, `describe-pr`, `handle-pr-feedback`) → bare `tracker <subcommand>`.
- `docs/tracker-portability.md`: the call-form references now show `tracker <subcommand>` and explain the `bin/`-on-PATH wrapper.
- `cross-review` is untouched - its `${CLAUDE_SKILL_DIR}/scripts/review.sh` is a correct reference to its *own* bundled script, not the tracker.
- Bump 0.1.6 → 0.1.7.

## Trade-off (accepted)

Bare `tracker` resolves via plugin `bin/`-on-PATH, so it works in **plugin install** mode (a freshly-started session) but **not** template-clone mode (where `bin/` isn't auto-on-PATH). That's intentional given the plugin-first direction; the template approach is being retired separately. It does **not** add Copilot tracker portability (`gh skill install` ships the skill folder, not `bin/`/the adapter) - so any "tracker portability" asterisk on slides stays.

## Verification

- 0 `CLAUDE_SKILL_DIR` references remain in the 7 tracker skills; 32 bare `tracker` calls present.
- `claude plugin validate .` passes.
- Empirically confirmed `tracker backend` → `github` via the PATH wrapper in a loaded session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)