### PR TITLE
init: automate workflow-state label creation via tracker adapter

### DIFF
--- a/.claude/scripts/tracker.sh
+++ b/.claude/scripts/tracker.sh
@@ -28,6 +28,8 @@
 # Subcommands (utility):
 #   repo-info                                 Owner + repo name as JSON.
 #   backend                                   Print the active backend name.
+#   setup-labels                              Create the 8 workflow-state labels
+#                                             (github only; no-op on other backends).
 #
 # Backend selection: reads `.claude/tracker.json` (gitignored) if present,
 # else `.claude/tracker.example.json`, else defaults to `github`. Override
@@ -123,6 +125,22 @@ gh_pr_review_comments() { gh_require; gh api "repos/:owner/:repo/pulls/$1/commen
 gh_pr_decision()     { gh_require; gh pr view "$1" --json reviewDecision; }
 gh_pr_closing_issues() { gh_require; gh pr view "$1" --json closingIssuesReferences --jq '.closingIssuesReferences[].number'; }
 gh_repo_info()       { gh_require; gh repo view --json owner,name; }
+
+# Create the 8 neutral workflow-state labels (the canonical set in AGENTS.md
+# "Workflow state lifecycle"). Idempotent via --force, so it is safe to re-run.
+# This function is the single source of truth for the label names/colors;
+# docs reference it rather than re-listing the commands.
+gh_setup_labels() {
+  gh_require
+  gh label create "research-in-progress"  --description "Research actively underway"              --color "1d76db" --force
+  gh label create "research-complete"      --description "Research done, ready for planning"       --color "0e8a16" --force
+  gh label create "planning-in-progress"   --description "Plan being created"                      --color "fbca04" --force
+  gh label create "ready-for-dev"          --description "Has implementation plan, ready to build" --color "5319e7" --force
+  gh label create "in-progress"            --description "Development actively underway"           --color "d93f0b" --force
+  gh label create "validation-failed"      --description "Implementation complete but failed validation" --color "d4c5f9" --force
+  gh label create "implementation-failed"  --description "Implementation could not be completed"   --color "b60205" --force
+  gh label create "pr-submitted"           --description "PR created, awaiting review"             --color "c2e0c6" --force
+}
 
 # ----------------------------------------------------------------------------
 # Azure DevOps backend
@@ -326,6 +344,7 @@ case "$BACKEND" in
       pr-decision) gh_pr_decision "$@" ;;
       pr-closing-issues) gh_pr_closing_issues "$@" ;;
       repo-info) gh_repo_info ;;
+      setup-labels) gh_setup_labels ;;
       *) abort "unknown subcommand for github backend: $SUBCMD" 2 ;;
     esac
     ;;
@@ -347,6 +366,7 @@ case "$BACKEND" in
       pr-decision) azdo_pr_decision "$@" ;;
       pr-closing-issues) azdo_pr_closing_issues "$@" ;;
       repo-info) azdo_repo_info ;;
+      setup-labels) echo "INFO: tracker=azure-devops; state tags are free-form and created on first set-state - nothing to pre-create" >&2 ;;
       *) abort "unknown subcommand for azure-devops backend: $SUBCMD" 2 ;;
     esac
     ;;
@@ -356,7 +376,7 @@ case "$BACKEND" in
       backend) echo none ;;
       view|pr-current|pr-view|pr-diff|pr-list-open|pr-reviews|pr-review-comments|pr-decision|pr-closing-issues|repo-info)
         none_query ;;
-      set-state|comment|pr-edit-body|pr-comment)
+      set-state|comment|pr-edit-body|pr-comment|setup-labels)
         none_mutating "$SUBCMD" ;;
       *) abort "unknown subcommand for none backend: $SUBCMD" 2 ;;
     esac

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -34,12 +34,21 @@ Check if `${CLAUDE_PROJECT_DIR}/.claude/tracker.json` exists.
   - Build the project's `.claude/tracker.json` with `"tracker": "<user-choice>"` and the corresponding backend block populated as much as you can from the example (keep the other backend blocks as inert reference - the adapter only reads the active one).
   - Create the `${CLAUDE_PROJECT_DIR}/.claude/` directory if it does not exist, then write the file.
   - Then per backend:
-    - `github`: tell the user to confirm `gh auth login` is done.
+    - `github`: tell the user to confirm `gh auth login` is done, then offer the label step below.
     - `azure-devops`: warn that the backend is currently a stub (PR 2 pending) - tag / state-transition writes will not yet happen.
     - `none`: tell the user nothing more is needed; mutating tracker calls become no-ops, queries return empty JSON.
 
 - **If it DOES exist:**
   - Tell the user: *".claude/tracker.json already exists; leaving it alone. If you want to change backend, edit it directly - see `${CLAUDE_PLUGIN_ROOT}/.claude/tracker.example.json` for the schema."*
+  - Read it to determine the active backend - the label step below still applies if it is `github`.
+
+### 2a. Workflow-state labels (github backend only)
+
+Only run this when the active backend is `github`. Skip it entirely for `azure-devops` (state tags are free-form, created on first transition) and `none`.
+
+- Ask the user: *"Create the 8 workflow-state labels in this repo now? This writes to the GitHub repo, so `gh auth login` must already be done. (yes / no)"*
+- If **yes**, run `bash ${CLAUDE_PROJECT_DIR}/.claude/scripts/tracker.sh setup-labels`. The command is idempotent (`gh label create --force`), so re-running is safe. If it fails (e.g. `gh` not authenticated), print the exact error and tell the user to run `gh auth login` and re-run the command - do not run the auth flow yourself.
+- If **no**, tell the user they can create them later with `bash .claude/scripts/tracker.sh setup-labels`.
 
 ### 3. Cross-vendor review (optional)
 

--- a/docs/TEMPLATE_INSTRUCTIONS.md
+++ b/docs/TEMPLATE_INSTRUCTIONS.md
@@ -319,6 +319,12 @@ Labels track issue state through the workflow. Both manual commands (`/research-
 
 #### Creating the Labels
 
+**Recommended: via Flow init / the tracker adapter.** `flow:init` offers to create the 8 core workflow-state labels for you (github backend only). To create them at any time, run the idempotent adapter subcommand, which is the single source of truth for the core label names/colors:
+```bash
+bash .claude/scripts/tracker.sh setup-labels
+```
+This covers the 8 core states. The Ralph-only `ralph-exempt` label is not part of the core set - create it with the manual command below if you use Ralph.
+
 **Option 1: Ask Claude to create them**
 ```
 Create the GitHub labels needed for Ralph autonomous workflow:


### PR DESCRIPTION
## What

Automates creation of the 8 core workflow-state labels as part of `flow:init` onboarding, instead of users copy-pasting `gh label create` commands.

## Changes

- **[tracker.sh](.claude/scripts/tracker.sh)**: new `setup-labels` subcommand.
  - `github`: creates the 8 core state labels (`research-in-progress`, `research-complete`, `planning-in-progress`, `ready-for-dev`, `in-progress`, `validation-failed`, `implementation-failed`, `pr-submitted`), idempotent via `gh label create --force`.
  - `azure-devops`: no-op (state tags are free-form, created on first `set-state`).
  - `none`: no-op.
  - This function is the single source of truth for the core label names/colors.
- **[init/SKILL.md](.claude/skills/init/SKILL.md)**: new step 2a offers to run `setup-labels` for github projects, gated on a yes/no confirmation and a `gh auth login` note. Running the auth flow stays out of scope.
- **[docs/TEMPLATE_INSTRUCTIONS.md](docs/TEMPLATE_INSTRUCTIONS.md)**: points at the adapter subcommand as the recommended way to create the core labels. The Ralph-only `ralph-exempt` label is explicitly out of the core set.

## Scope

Per request, only the **8 core states** - not `ralph-exempt` or the dynamic `blocked-by-#N`.

## Verification

- `bash -n` syntax check passes.
- `none` and `azure-devops` backends dispatch to no-op messages (tested).
- github dispatch routes to `gh_setup_labels`; not executed against a live repo as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)