### PR TITLE
research-requirements: drop dead link to non-existent workflow-concepts doc

### DIFF
--- a/.claude/skills/research-requirements/SKILL.md
+++ b/.claude/skills/research-requirements/SKILL.md
@@ -230,5 +230,4 @@ Please review the research document. Once you've resolved any open questions, yo
 ## References
 
 - Pattern reference: [`.claude/skills/research-codebase/SKILL.md`](.claude/skills/research-codebase/SKILL.md)
-- Workflow concepts: [`docs/claude-code-workflow-concepts.md`](docs/claude-code-workflow-concepts.md)
 - Output directory: `flow/research/`


### PR DESCRIPTION
## What

The `## References` section of `research-requirements/SKILL.md` linked to `docs/claude-code-workflow-concepts.md`, which has never existed in this repo. Removes the dead bullet.

This is the pre-existing broken link flagged during the Ralph/template cleanup (#51).

## Scope

A sweep of all markdown files for dangling local doc links turned up no other genuine broken links - the remaining hits were illustrative placeholders (`path`, `url`, `src/backend/config.py`) or root-relative links that resolve to real files.

## Verification

- `grep -rn "claude-code-workflow-concepts"` over the tree → zero matches.