### PR TITLE
docs: use static release badge, drop last-commit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Flow
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/corticalstack/flow?include_prereleases&sort=semver)](https://github.com/corticalstack/flow/releases)
-[![Last commit](https://img.shields.io/github/last-commit/corticalstack/flow)](https://github.com/corticalstack/flow/commits)
+[![Release](https://img.shields.io/badge/release-v0.1.8-blue)](https://github.com/corticalstack/flow/releases)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-D97757?logo=anthropic&logoColor=white)](https://docs.claude.com/en/docs/claude-code)
 [![GitHub Copilot CLI](https://img.shields.io/badge/GitHub%20Copilot-CLI-000000?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Agent Skills](https://img.shields.io/badge/Agent%20Skills-open%20standard-6E56CF)](https://agentskills.io/specification)


### PR DESCRIPTION
## Why

The README's `github/v/release` and `github/last-commit` badges hit shields.io's **shared GitHub API token pool**, which is currently rate-limited and renders **"Unable to select next GitHub token from pool"** instead of a value. The other badges are static `img.shields.io/badge/...` and are unaffected.

## Change

- **Release** badge → static `release-v0.1.8` (verified rendering; bumped at release time).
- **Last commit** badge → removed (no static equivalent, lowest-value badge).

No API-dependent badges remain, so this failure mode can't recur.

## Follow-up

When cutting a future release, also bump the `release-vX.Y.Z` value in the README badge.