### PR TITLE
chore: re-baseline plugin version to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flow",
   "displayName": "Flow",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "A cross-tool agentic-coding workflow toolkit: 11 workflow skills (research / plan / implement / validate / commit / describe-pr / handle-pr-feedback / handoffs), an optional cross-vendor code-review skill, an LLM-as-judge evaluation skill, and a tracker abstraction (GitHub Issues, Azure DevOps work items, ...). Built on the Agent Skills open standard so the same files work in Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "corticalstack"


### PR DESCRIPTION
## Why

The sole GitHub release was `v0.1.8`, matching the manifest. But the `0.1.x` series was bumped only in `plugin.json` across PRs (#37-#51) with no releases cut, so a lone `v0.1.8` reads as if `0.1.0`-`0.1.7` releases went missing.

Re-baseline to `0.2.0`: a clean, intentional first tagged release of the reframed plugin, staying honestly pre-1.0.

## Change

- `.claude-plugin/plugin.json`: `version` `0.1.8` → `0.2.0` (only file that carries a version).

## Follow-up (after merge)

- Delete the `v0.1.8` GitHub release + tag, cut `v0.2.0` targeting the merged `main`.
- The README release badge is dynamic (`github/v/release`), so it will pick up `v0.2.0` automatically.